### PR TITLE
Visual Basic JIT Expression Compiler

### DIFF
--- a/src/Test/TestCases.Workflows/JitCompilerTests.cs
+++ b/src/Test/TestCases.Workflows/JitCompilerTests.cs
@@ -1,0 +1,110 @@
+﻿using Shouldly;
+using System;
+using System.Activities;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace TestCases.Workflows
+{
+    public class JitCompilerTests
+    {
+        private readonly CSharpJitCompiler _csJitCompiler;
+        private readonly VbJitCompiler _vbJitCompiler;
+        private readonly string[] _namespaces;
+
+        public JitCompilerTests()
+        {
+            _namespaces = new[] { "TestCases.Workflows", "System", "System.Linq", "System.Linq.Expressions", "System.Collections.Generic" };
+            _vbJitCompiler = new(new HashSet<Assembly> { typeof(string).Assembly, typeof(ClassWithIndexer).Assembly, typeof(Expression).Assembly, typeof(Enumerable).Assembly });
+            _csJitCompiler = new(new HashSet<Assembly> { typeof(string).Assembly, typeof(ClassWithIndexer).Assembly, typeof(Expression).Assembly, typeof(Enumerable).Assembly });
+        }
+
+        [Fact]
+        public void VisualBasicJitCompiler_PropertyAccess()
+        {
+            var expressionToCompile = "testIndexerClass.Indexer(indexer)";
+            var result = _vbJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, VariableTypeGetter, typeof(string)));
+            ((Func<TestIndexerClass, string, string>)result.Compile())(new TestIndexerClass(), "index").ShouldBe("index");
+        }
+
+        [Fact]
+        public void VisualBasicJitCompiler_MethodCall()
+        {
+            var expressionToCompile = "testIndexerClass.Method(method)";
+            var result = _vbJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, VariableTypeGetter, typeof(string)));
+            ((Func<TestIndexerClass, string, string>)result.Compile())(new TestIndexerClass(), "method").ShouldBe("method");
+        }
+
+        [Fact]
+        public void VisualBasicJitCompiler_FieldAccess()
+        {
+            var expressionToCompile = "testIndexerClass.Field + field";
+            var result = _vbJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, VariableTypeGetter, typeof(string)));
+            ((Func<TestIndexerClass, string, string>)result.Compile())(new TestIndexerClass(), "field").ShouldBe("field");
+        }
+
+        [Fact]
+        public void VisualBasicJitCompiler_PropertyAccess_SameNameAsVariable()
+        {
+            static Type VariableTypeGetter(string name)
+            {
+                return name switch
+                {
+                    "Indexer" => typeof(TestIndexerClass),
+                    _ => typeof(string),
+                };
+            }
+
+            var expressionToCompile = "Indexer.Indexer(\"indexer\")";
+            var result = _vbJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, VariableTypeGetter, typeof(string)));
+            ((Func<TestIndexerClass, string>)result.Compile())(new TestIndexerClass()).ShouldBe("indexer");
+        }
+
+        [Fact]
+        public void CSharpJitCompiler_PropertyAccess()
+        {
+            static Type VariableTypeGetter(string name)
+            {
+                return name switch
+                {
+                    "testIndexerClass" => typeof(TestIndexerClass),
+                    "Indexer" => typeof(int), // consider we have "Indexer" variable declared in the current context.
+                    "indexer" => typeof(string),
+                    _ => null
+                };
+            }
+
+            var expressionToCompile = "testIndexerClass.Indexer[indexer]";
+            var result = _csJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, VariableTypeGetter, typeof(string)));
+
+            // "Indexer" variable is added as a parameter, but it is fine, that does not trigger a validation error.
+            ((Func<TestIndexerClass, int, string, string>)result.Compile())(new TestIndexerClass(), 0, "index").ShouldBe("index");
+        }
+
+        private static Type VariableTypeGetter(string name)
+            => name switch
+            {
+                "testIndexerClass" => typeof(TestIndexerClass),
+                _ => typeof(string),
+            };
+    }
+
+    public class ClassWithIndexer
+    {
+        public ClassWithIndexer() {}
+        public string this[string indexer] => indexer;
+    }
+    
+    public class TestIndexerClass
+    {
+        public string Field = string.Empty;
+        public TestIndexerClass() {}
+#pragma warning disable CA1822 // Mark members as static
+        public ClassWithIndexer Indexer { get => new(); }
+        public string Method(string method) => method;
+#pragma warning restore CA1822 // Mark members as static
+    }
+}

--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -40,6 +40,7 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
 
     protected MetadataReference[] MetadataReferences { get; set; }
     protected abstract int IdentifierKind { get; }
+    protected virtual StringComparer IdentifierNameComparer => StringComparer.Ordinal;
     protected abstract string CreateExpressionCode(string types, string names, string code);
     protected abstract string GetTypeName(Type type);
     protected abstract Script<object> Create(string code, ScriptOptions options);
@@ -81,7 +82,7 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
     public IEnumerable<string> GetIdentifiers(SyntaxTree syntaxTree)
     {
         return syntaxTree.GetRoot().DescendantNodesAndSelf().Where(n => n.RawKind == IdentifierKind)
-                         .Select(n => n.ToString()).Distinct().ToArray();
+                         .Select(n => n.ToString()).Distinct(IdentifierNameComparer).ToArray();
     }
 }
 
@@ -110,6 +111,7 @@ public class VbJitCompiler : ScriptingJitCompiler
     public VbJitCompiler(HashSet<Assembly> referencedAssemblies) : base(referencedAssemblies) { }
 
     protected override int IdentifierKind => (int) SyntaxKind.IdentifierName;
+    protected override StringComparer IdentifierNameComparer => StringComparer.OrdinalIgnoreCase;
 
     protected override Script<object> Create(string code, ScriptOptions options) =>
         VisualBasicScript.Create("? " + code, options);


### PR DESCRIPTION
This PR is addressing a problem related to visual basic expressions compilation.
Expression identifiers are compared with workflow variables, which can lead to declaring bad parameters for the generated lambda expression.
Example: 
`Excel.Sheet("sheet").Range(range)` is transformed into:
`Public Shared Function CreateExpression() As Expression(Of Func(Of UiPath.Excel.IWorkbookQuickHandle, String, String, UiPath.Excel.IReadRangeRef))
     Return Function(Excel, Range, range) (Excel.Sheet("sheet").Range(Range))
End Function`

The initial expression contains 4 IdentifierNames, where `Excel` and `range` are the only variables. The matching algorithm (see `ExpressionToCompile.VariableTypeGetter`) will consider the `Range` property to be a variable, which is not true, and will declare it as a parameter. 
A validation error will be visible in the designer because now we're passing 2 parameters with the same name.
Please see the tests for more details.

A possible solution, which may not be the best, is avoiding identifiers that are certainly not variables.