### PR TITLE
Refactor validator, fix expression issues [UI-54756] [UI-55419] [UI-53852]

### DIFF
--- a/src/Perf/CoreWf.Benchmarks/Expressions.cs
+++ b/src/Perf/CoreWf.Benchmarks/Expressions.cs
@@ -16,6 +16,7 @@ public class Expressions
     private readonly Activity[] _vbSingleExpr100;
     private readonly Activity[] _cs400Stmts;
     private int _activityIndex;
+    private readonly ValidationSettings _useValidator = new() { ForceExpressionCache = false };
 
     public Expressions()
     {
@@ -53,7 +54,7 @@ public class Expressions
     {
         var activity = _vb100Stmts[_activityIndex];
         _activityIndex = (_activityIndex + 1) % _vb100Stmts.Length;
-        _ = ActivityValidationServices.Validate(activity);
+        _ = ActivityValidationServices.Validate(activity, _useValidator);
     }
 
     [Benchmark]
@@ -61,7 +62,7 @@ public class Expressions
     {
         var activity = _vb400Stmts[_activityIndex];
         _activityIndex = (_activityIndex + 1) % _vb400Stmts.Length;
-        _ = ActivityValidationServices.Validate(activity);
+        _ = ActivityValidationServices.Validate(activity, _useValidator);
     }
 
     //[Benchmark]
@@ -69,7 +70,7 @@ public class Expressions
     {
         var activity = _vbSingleExpr100[_activityIndex];
         _activityIndex = (_activityIndex + 1) % _vbSingleExpr100.Length;
-        _ = ActivityValidationServices.Validate(activity);
+        _ = ActivityValidationServices.Validate(activity, _useValidator);
     }
 
     [Benchmark]
@@ -109,7 +110,7 @@ public class Expressions
     {
         var activity = _cs400Stmts[_activityIndex];
         _activityIndex = (_activityIndex + 1) % _cs400Stmts.Length;
-        _ = ActivityValidationServices.Validate(activity);
+        _ = ActivityValidationServices.Validate(activity, _useValidator);
     }
 
     private static Activity GenerateManyExpressionsWorkflow(int startExprNum, int numExpressions, string language = "VB")

--- a/src/Test/CustomTestObjects/ClassWithCollectionProperties.cs
+++ b/src/Test/CustomTestObjects/ClassWithCollectionProperties.cs
@@ -1,0 +1,6 @@
+﻿namespace CustomTestObjects;
+
+public class ClassWithCollectionProperties
+{
+    public Dictionary<string, object> FooDictionary { get; set; } = new();
+}

--- a/src/Test/CustomTestObjects/CustomTestObjects.csproj
+++ b/src/Test/CustomTestObjects/CustomTestObjects.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Test/TestCases.Workflows/ExpressionTests.cs
+++ b/src/Test/TestCases.Workflows/ExpressionTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CSharp.Activities;
+﻿using CustomTestObjects;
+using Microsoft.CSharp.Activities;
 using Microsoft.VisualBasic.Activities;
 using Shouldly;
 using System.Activities;
@@ -38,6 +39,13 @@ public class ExpressionTests
             yield return new object[] { $@"string.Join(',', ""alpha"", l[0], 1, ""beta"")" };
             yield return new object[] { $@"string.Join(',', ""alpha"", d[""gamma""], 1, ""beta"")" };
         }
+    }
+
+    static ExpressionTests()
+    {
+        // There's no programmatic way (that I know of) to add assembly references when creating workflows like in these tests.
+        // Adding the custom assembly directly to the expression validator to simulate XAML reference.
+        VbExpressionValidator.Instance = new VbExpressionValidator(new() { typeof(ClassWithCollectionProperties).Assembly });
     }
 
     [Theory]
@@ -163,12 +171,12 @@ public class ExpressionTests
     [Fact]
     public void Vb_Dictionary()
     {
-        VisualBasicValue<string> vbv = new("something.EquivalentGroupsDictionary(\"key\").ToString()");
+        VisualBasicValue<string> vbv = new("something.FooDictionary(\"key\").ToString()");
         WriteLine writeLine = new();
         writeLine.Text = new InArgument<string>(vbv);
         Sequence workflow = new();
         workflow.Activities.Add(writeLine);
-        workflow.Variables.Add(new Variable<ValidationHelper.OverloadGroupEquivalenceInfo>("something"));
+        workflow.Variables.Add(new Variable<ClassWithCollectionProperties>("something"));
 
         ValidationResults validationResults = ActivityValidationServices.Validate(workflow, _useValidator);
         validationResults.Errors.Count.ShouldBe(0, string.Join("\n", validationResults.Errors.Select(e => e.Message)));

--- a/src/Test/TestCases.Workflows/TestCases.Workflows.csproj
+++ b/src/Test/TestCases.Workflows/TestCases.Workflows.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\UiPath.Workflow\UiPath.Workflow.csproj" />
+    <ProjectReference Include="..\CustomTestObjects\CustomTestObjects.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Page Remove="**\*.xaml" />

--- a/src/UiPath.Workflow.Runtime/Validation/ValidationHelper.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ValidationHelper.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace System.Activities.Validation;
 
-internal static class ValidationHelper
+public static class ValidationHelper
 {
     public static void ValidateArguments(
         Activity activity,

--- a/src/UiPath.Workflow.Runtime/Validation/ValidationHelper.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ValidationHelper.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace System.Activities.Validation;
 
-public static class ValidationHelper
+internal static class ValidationHelper
 {
     public static void ValidateArguments(
         Activity activity,

--- a/src/UiPath.Workflow.sln
+++ b/src/UiPath.Workflow.sln
@@ -46,6 +46,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Perf", "Perf", "{8E6A125F-0
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreWf.Benchmarks", "Perf\CoreWf.Benchmarks\CoreWf.Benchmarks.csproj", "{FE1D4185-DF43-467C-8380-CBA60C6B92DA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomTestObjects", "Test\CustomTestObjects\CustomTestObjects.csproj", "{E8CED08F-0838-4167-AA20-5BD42372558E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -112,6 +114,10 @@ Global
 		{FE1D4185-DF43-467C-8380-CBA60C6B92DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FE1D4185-DF43-467C-8380-CBA60C6B92DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FE1D4185-DF43-467C-8380-CBA60C6B92DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8CED08F-0838-4167-AA20-5BD42372558E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8CED08F-0838-4167-AA20-5BD42372558E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8CED08F-0838-4167-AA20-5BD42372558E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8CED08F-0838-4167-AA20-5BD42372558E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -127,6 +133,7 @@ Global
 		{A5B620F9-4E5F-4130-A524-EC1E8C11249B} = {4D92EFCA-7902-49DE-B98F-8CF7675ED86C}
 		{154DD961-CA7E-410A-B31F-E057A06E2A68} = {4D92EFCA-7902-49DE-B98F-8CF7675ED86C}
 		{FE1D4185-DF43-467C-8380-CBA60C6B92DA} = {8E6A125F-0530-4D8E-8CD4-3429DAF57706}
+		{E8CED08F-0838-4167-AA20-5BD42372558E} = {4D92EFCA-7902-49DE-B98F-8CF7675ED86C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1ED6A6D7-ACEE-4780-B630-50DCAED74BA9}

--- a/src/UiPath.Workflow/Activities/ExpressionContainer.cs
+++ b/src/UiPath.Workflow/Activities/ExpressionContainer.cs
@@ -1,0 +1,47 @@
+﻿using System.Activities.XamlIntegration;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace System.Activities;
+
+/// <summary>
+///     Contains all the relevant information regarding the validation of an expression.
+/// </summary>
+public class ExpressionContainer
+{
+    /// <summary>
+    ///     The type returned from the expression.
+    /// </summary>
+    public Type ResultType { get; set; }
+
+    /// <summary>
+    ///     The current compilation object.
+    /// </summary>
+    public Compilation CompilationUnit { get; set; }
+
+    /// <summary>
+    ///     Expression text, imported namespaces, and variable type getter function.
+    /// </summary>
+    public ExpressionToCompile ExpressionToValidate { get; set; }
+
+    /// <summary>
+    ///     Activity that owns the expression.
+    /// </summary>
+    public Activity CurrentActivity { get; set; }
+
+    /// <summary>
+    ///     LRE to contain the in-scope identifiers.
+    /// </summary>
+    public LocationReferenceEnvironment Environment { get; set; }
+
+    /// <summary>
+    ///     Assemblies required to validate the expression.
+    /// </summary>
+    public ICollection<Assembly> RequiredAssemblies { get; set; }
+
+    /// <summary>
+    ///     Diagnostics reported by validating the expression.
+    /// </summary>
+    public IEnumerable<TextExpressionCompilerError> Diagnostics { get; set; }
+}

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicSettings.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicSettings.cs
@@ -27,10 +27,11 @@ public class VisualBasicSettings
         //"mscorlib"
         new VisualBasicImportReference {Import = "System", Assembly = typeof(object).Assembly.FullName},
         new VisualBasicImportReference {Import = "System.Collections", Assembly = "System.Runtime"},
-        new VisualBasicImportReference {Import = "System.Collections.Generic", Assembly = "System.Runtime"},
+        new VisualBasicImportReference {Import = "System.Collections.Generic", Assembly = "System.Collections"},
         //"system"
         new VisualBasicImportReference
             {Import = "System.ComponentModel", Assembly = typeof(BrowsableAttribute).Assembly.FullName},
+        new VisualBasicImportReference { Import = "System.Linq", Assembly = typeof(System.Linq.Enumerable).Assembly.FullName },
         new VisualBasicImportReference
             {Import = "System.Linq.Expressions", Assembly = typeof(Expression).Assembly.FullName},
         new VisualBasicImportReference {Import = "System", Assembly = "system"},


### PR DESCRIPTION
Added an ExpressionContainer class to hold the data on an expression on its way through validation. This allows the extension points to get access to the activity, LRE, imported namespaces, referenced assemblies, etc. and make changes to these at extension points in the validation process.

Also fixed a few bugs. Dictionary access would not work without the System.Collections assembly included, which is due to newer versions of .NET splitting out namespaces from what used to be mscorlib. Linq extensions are also included by default. VB overflow checking is now turned out so that if, for example, a constant expression returns a value that would overflow an integer there will be a validation error.