### PR TITLE
fix: expressions compilation failure will bubble up only errors

### DIFF
--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -3,6 +3,7 @@
 
 using System.Activities.ExpressionParser;
 using System.Activities.Internals;
+using System.Activities.XamlIntegration;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -72,8 +73,13 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
         var results = ScriptingAotCompiler.BuildAssembly(finalCompilation);
         if (results.HasErrors)
         {
+            var errorResults = new TextExpressionCompilerResults
+            {
+                ResultType = results.ResultType,
+            };
+            errorResults.AddMessages(results.CompilerMessages.Where(m => !m.IsWarning));
             throw FxTrace.Exception.AsError(new SourceExpressionException(
-                SR.CompilerErrorSpecificExpression(expressionToCompile.Code, results), results.CompilerMessages));
+                SR.CompilerErrorSpecificExpression(expressionToCompile.Code, errorResults), errorResults.CompilerMessages));
         }
 
         return (LambdaExpression) results.ResultType.GetMethod("CreateExpression")!.Invoke(null, null);


### PR DESCRIPTION
On expressions compilation failure, as part of the thrown exception, we were also adding the warnings resulting from the compilation process. This behavior is not consistent with the generated output of the equivalent functionality in Net Framework, which uses just the errors, without the warnings.

[UI-51453](https://uipath.atlassian.net/browse/UI-51453). Compilation warnings for missing namespace sources are visible as part of the error messages of all invalid activities for NET5 projects 