### PR TITLE
Fix expression reference issue, make Validate virtual

### DIFF
--- a/src/UiPath.Workflow/Activities/VbExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/VbExpressionValidator.cs
@@ -89,12 +89,7 @@ public class VbExpressionValidator : RoslynExpressionValidator
         {
             var options = DefaultCompilationUnit.Options as VisualBasicCompilationOptions;
             var compilation = DefaultCompilationUnit.WithOptions(options!.WithGlobalImports(globalImports));
-
-            var missingReferences = compilation.References.Except(metadataReferences);
-            expressionContainer.CompilationUnit = 
-                missingReferences.Any() 
-                ? compilation.AddReferences(missingReferences) 
-                : compilation;
+            expressionContainer.CompilationUnit = compilation.WithReferences(metadataReferences);
         }
     }
 


### PR DESCRIPTION
Previous code for setting the references on the Compilation object wasn't adding all the assemblies needed in certain scenarios. Found it's better to just replace the references. Also making Validate method virtual so subclasses can add instrumentation.