### PR TITLE
fix: replace dotnet with msbuild to fix missing zh-CN culture

### DIFF
--- a/.pipelines/build.yaml
+++ b/.pipelines/build.yaml
@@ -24,17 +24,27 @@ jobs:
         Write-Host "Version that will be used is $fullVersion"
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet build
-    inputs:
-      projects: src/UiPath.Workflow.sln
-      arguments: --configuration $(BuildConfiguration) -p:Version="$(Version)"
-
-  - task: DotNetCoreCLI@2
     displayName: dotnet test
     inputs:
       command: test
       projects: src
-      arguments: --no-build --configuration $(BuildConfiguration) --collect "Code Coverage" --settings src/CodeCoverage.runsettings
+      arguments: --configuration $(BuildConfiguration) --collect "Code Coverage" --settings src/CodeCoverage.runsettings
+      
+  - task: DeleteFiles@1
+    displayName: Remove tests output
+    inputs:
+      SourceFolder: src
+      Contents: |
+        UiPath.Workflow.Runtime\bin\$(BuildConfiguration)\*.*nupkg
+        UiPath.Workflow\bin\$(BuildConfiguration)\*.*nupkg
+        
+  - task: MSBuild@1
+    displayName: msbuild
+    inputs:
+      solution: src/UiPath.Workflow.sln
+      configuration: $(BuildConfiguration)
+      msbuildArguments: /t:restore /p:Version="$(Version)" /t:Rebuild
+      restoreNugetPackages: true
 
   - task: CopyFiles@2
     displayName: 'Copy Files to: Build.ArtifactStagingDirectory'


### PR DESCRIPTION
There is a bug when building with dotnet CLI, the Chinese culture is missing from the build output. 

https://github.com/dotnet/sdk/issues/24580

This PR replaces dotnet CLI with msbuild 