### PR TITLE
Remove lock around compiler usage

### DIFF
--- a/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
@@ -1385,26 +1385,21 @@ internal abstract class JitCompilerHelper<TLanguage> : JitCompilerHelper
         var compilerWrapper = GetCachedHostedCompiler(ReferencedAssemblies);
         var compiler = compilerWrapper.Compiler;
         LambdaExpression lambda = null;
+        
         try
         {
-            lock (compiler)
+            lambda = compiler.CompileExpression(ExpressionToCompile(scriptAndTypeScope.FindVariable,
+                typeof(object)));
+        }
+        catch (Exception e)
+        {
+            if (Fx.IsFatal(e))
             {
-                try
-                {
-                    lambda = compiler.CompileExpression(ExpressionToCompile(scriptAndTypeScope.FindVariable,
-                        typeof(object)));
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    ExceptionTrace.TraceUnhandledException(e);
-                    throw;
-                }
+                throw;
             }
+
+            ExceptionTrace.TraceUnhandledException(e);
+            throw;
         }
         finally
         {
@@ -1521,25 +1516,19 @@ internal abstract class JitCompilerHelper<TLanguage> : JitCompilerHelper
         LambdaExpression lambda = null;
         try
         {
-            lock (compiler)
+            lambda = compiler.CompileExpression(ExpressionToCompile(scriptAndTypeScope.FindVariable,
+                lambdaReturnType));
+        }
+        catch (Exception e)
+        {
+            if (Fx.IsFatal(e))
             {
-                try
-                {
-                    lambda = compiler.CompileExpression(ExpressionToCompile(scriptAndTypeScope.FindVariable,
-                        lambdaReturnType));
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    // We never want to end up here, Compiler bugs needs to be fixed.
-                    ExceptionTrace.TraceUnhandledException(e);
-                    throw;
-                }
+                throw;
             }
+
+            // We never want to end up here, Compiler bugs needs to be fixed.
+            ExceptionTrace.TraceUnhandledException(e);
+            throw;
         }
         finally
         {

--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -39,7 +39,7 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
         MetadataReferences = referencedAssemblies.GetMetadataReferences().ToArray();
     }
 
-    protected MetadataReference[] MetadataReferences { get; set; }
+    protected IReadOnlyCollection<MetadataReference> MetadataReferences { get; init; }
     protected abstract int IdentifierKind { get; }
     protected virtual StringComparer IdentifierNameComparer => StringComparer.Ordinal;
     protected abstract string CreateExpressionCode(string types, string names, string code);


### PR DESCRIPTION
This `lock` can introduce significant delay in certain scenarios when the validation is executed on multiple threads.
My test scenario:
- project with 24 files
- Studio attempts to validate using 8 threads
-> referenced assemblies for the files are rather similar resulting in only 4 cached compilers being created.
-> threads are fighting (locking) over these compilers; the more in-demand a certain compiler is, the more visible the effect 

In some test runs I did, we spent up to half the validation time just waiting for the compiler.

I've checked the underlying classes and there doesn't seem to be any state to warrant the lock. I mean, the only state would be the `MetadataReference` which we never modify. I've changed it to `IReadOnlyCollection` and replaced the `set` with an `init` to make this more obvious.

* As I understand it, this impacts runtime/execution as well (not just the validation flow).