### PR TITLE
Microsoft.VisualBasic as default namespace for VB validation

### DIFF
--- a/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
@@ -55,7 +55,7 @@ internal abstract class JitCompilerHelper
 
     protected virtual void OnCompilerCacheCreated(CompilerCache compilerCache) { }
 
-    protected void Initialize(HashSet<AssemblyName> refAssemNames, HashSet<string> namespaceImportsNames)
+    protected virtual void Initialize(HashSet<AssemblyName> refAssemNames, HashSet<string> namespaceImportsNames)
     {
         namespaceImportsNames.Add("System");
         namespaceImportsNames.Add("System.Linq.Expressions");

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicDesignerHelper.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicDesignerHelper.cs
@@ -39,6 +39,12 @@ internal class VisualBasicHelper : JitCompilerHelper<VisualBasicHelper>
         };
     }
 
+    protected override void Initialize(HashSet<AssemblyName> refAssemNames, HashSet<string> namespaceImportsNames)
+    {
+        namespaceImportsNames.Add("Microsoft.VisualBasic");
+        base.Initialize(refAssemNames, namespaceImportsNames);
+    }
+
     public static Expression<Func<ActivityContext, T>> Compile<T>(string expressionText,
         CodeActivityPublicEnvironmentAccessor publicAccessor, bool isLocationExpression)
     {


### PR DESCRIPTION
In Visual Studio, when programming in VisualBasic, there is no need to import "Microsoft.VisualBasic" namespace in order to use expressions like "Now.ToString" (instead of DateAndTime.Now.ToString) - thanks to the fact, "Microsoft.VisualBasic" namespace is automatically imported by project file. But VisualBasicDesignerHelper class requires "Microsoft.VisualBasic" namespace to be passed as part of "namespaceImportsNames" set. This has an implication, that in environments where WF is ported to, expressions like "Now.ToString" are not validated without "Microsoft.VisualBasic" namespace, despite they are in VisualStudio. This causes inconsistent experience.
