### PR TITLE
Make light validation flow thread-safe, fix compilation

### DIFF
--- a/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
@@ -90,7 +90,7 @@ internal abstract class JitCompilerHelper
     public static void GetAllImportReferences(Activity activity, bool isDesignTime, out List<string> namespaces,
         out List<AssemblyReference> assemblies)
     {
-        var namespaceList = new List<string>();
+        var namespaceList = new List<string>() { "System.Linq.Expressions" };
         var assemblyList = new List<AssemblyReference>();
 
         // Start with the defaults; any settings on the Activity will be added to these

--- a/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
@@ -37,8 +37,6 @@ internal abstract class JitCompilerHelper
         typeof(Activity).Assembly // System.Activities
     };
 
-    private static HashSet<string> DefaultNamespaces = new HashSet<string> { "System", "System.Linq.Expressions" };
-
     private static readonly object s_typeReferenceCacheLock = new();
     private static readonly HopperCache s_typeReferenceCache = new(TypeReferenceCacheMaxSize, false);
     private static readonly FindMatch s_delegateFindLocationReferenceMatchShortcut = FindLocationReferenceMatchShortcut;
@@ -91,16 +89,12 @@ internal abstract class JitCompilerHelper
     {
         namespaceImportsNames.Remove("");
         namespaceImportsNames.Remove(null);
-        foreach (var ns in DefaultNamespaces)
-        {
-            namespaceImportsNames.Add(ns);
-        }
     }
 
     public static void GetAllImportReferences(Activity activity, bool isDesignTime, out List<string> namespaces,
         out List<AssemblyReference> assemblies)
     {
-        var namespaceList = new List<string>(DefaultNamespaces);
+        var namespaceList = new List<string>();
         var assemblyList = new List<AssemblyReference>();
 
         // Start with the defaults; any settings on the Activity will be added to these

--- a/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
@@ -89,6 +89,8 @@ internal abstract class JitCompilerHelper
     {
         namespaceImportsNames.Remove("");
         namespaceImportsNames.Remove(null);
+        namespaceImportsNames.Add("System");
+        namespaceImportsNames.Add("System.Linq.Expressions");
     }
 
     public static void GetAllImportReferences(Activity activity, bool isDesignTime, out List<string> namespaces,

--- a/src/UiPath.Workflow/Activities/RoslynExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/RoslynExpressionValidator.cs
@@ -1,15 +1,16 @@
 ﻿// This file is part of Core WF which is licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 using System.Activities.Expressions;
 using System.Activities.Validation;
 using System.Activities.XamlIntegration;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 
 namespace System.Activities;
 
@@ -18,9 +19,14 @@ namespace System.Activities;
 /// </summary>
 public abstract class RoslynExpressionValidator
 {
+    private readonly IReadOnlyCollection<string> _defaultNamespaces = new string[]
+    {
+        "System",
+        "System.Linq.Expressions"
+    };
+
     private const string Comma = ", ";
-    private readonly Lazy<Dictionary<Assembly, MetadataReference>> _metadataReferenceDictionary;
-    private readonly object _lockRequiredAssemblies = new();
+    private readonly Lazy<ConcurrentDictionary<Assembly, MetadataReference>> _metadataReferences;
 
     /// <summary>
     ///     Initializes the MetadataReference collection.
@@ -31,15 +37,14 @@ public abstract class RoslynExpressionValidator
     /// </param>
     protected RoslynExpressionValidator(HashSet<Assembly> seedAssemblies = null)
     {
-        _metadataReferenceDictionary = new(GetInitialMetadataReferences);
-        var assembliesToReference = new HashSet<Assembly>();
-        assembliesToReference.UnionWith(JitCompilerHelper.DefaultReferencedAssemblies);
+        _metadataReferences = new(GetInitialMetadataReferences);
+
+        var assembliesToReference = new HashSet<Assembly>(JitCompilerHelper.DefaultReferencedAssemblies);
         if (seedAssemblies != null)
         {
-            assembliesToReference.UnionWith(seedAssemblies);
+            assembliesToReference.UnionWith(seedAssemblies.Where(a => a is not null));
         }
 
-        assembliesToReference.RemoveWhere(x => x == null);
         RequiredAssemblies = assembliesToReference;
     }
 
@@ -47,7 +52,7 @@ public abstract class RoslynExpressionValidator
     ///     Assemblies required on the <see cref="Compilation"/> object. Use <see cref="AddRequiredAssembly(Assembly)"/>
     ///     to add more assemblies.
     /// </summary>
-    protected IReadOnlySet<Assembly> RequiredAssemblies { get; private set; }
+    protected IReadOnlySet<Assembly> RequiredAssemblies { get; init; }
 
     /// <summary>
     ///     The kind of identifier to look for in the syntax tree as variables that need to be resolved for the expression.
@@ -55,38 +60,12 @@ public abstract class RoslynExpressionValidator
     protected abstract int IdentifierKind { get; }
 
     /// <summary>
-    ///     Adds an assembly to the <see cref="RequiredAssemblies"/> set.
-    /// </summary>
-    /// <param name="assembly">assembly</param>
-    /// <remarks>
-    ///     Takes a lock and replaces <see cref="RequiredAssemblies"/> with a new set. Lock is taken in case
-    ///     multiple threads are adding assemblies simultaneously.
-    /// </remarks>
-    public void AddRequiredAssembly(Assembly assembly)
-    {
-        if (!RequiredAssemblies.Contains(assembly))
-        {
-            lock (_lockRequiredAssemblies)
-            {
-                if (!RequiredAssemblies.Contains(assembly))
-                {
-                    RequiredAssemblies = new HashSet<Assembly>(RequiredAssemblies)
-                    {
-                        assembly
-                    };
-                }
-            }
-        }
-    }
-
-    /// <summary>
     ///     Gets the MetadataReference objects for all of the referenced assemblies that expression requires.
     /// </summary>
     /// <param name="expressionContainer">expression container</param>
     /// <returns>MetadataReference objects for all required assemblies</returns>
     protected IEnumerable<MetadataReference> GetMetadataReferencesForExpression(ExpressionContainer expressionContainer) =>
-        expressionContainer.RequiredAssemblies.Where(asm => asm != null)
-        .Select(asm => TryGetMetadataReference(asm)).Where(mr => mr != null);
+        expressionContainer.RequiredAssemblies.Select(asm => TryGetMetadataReference(asm)).Where(mr => mr is not null);
 
     /// <summary>
     ///     Gets the type name, which can be language-specific.
@@ -154,8 +133,10 @@ public abstract class RoslynExpressionValidator
         };
 
         JitCompilerHelper.GetAllImportReferences(currentActivity, true, out var localNamespaces, out var localAssemblies);
-        requiredAssemblies.UnionWith(localAssemblies.Select(asmRef => asmRef.Assembly ?? LoadAssemblyFromReference(asmRef)));
+        requiredAssemblies.UnionWith(localAssemblies.Where(aref => aref is not null).Select(aref => aref.Assembly ?? LoadAssemblyFromReference(aref)));
         expressionContainer.RequiredAssemblies = requiredAssemblies;
+
+        localNamespaces.AddRange(_defaultNamespaces);
 
         var scriptAndTypeScope = new JitCompilerHelper.ScriptAndTypeScope(environment);
         expressionContainer.ExpressionToValidate =
@@ -279,12 +260,12 @@ public abstract class RoslynExpressionValidator
         foreach (var baseType in allBaseTypes)
         {
             var asm = baseType.Assembly;
-            if (!_metadataReferenceDictionary.Value.ContainsKey(asm))
+            if (!_metadataReferences.Value.ContainsKey(asm))
             {
                 var meta = GetMetadataReferenceForAssembly(asm);
                 if (meta != null)
                 {
-                    _metadataReferenceDictionary.Value.Add(asm, meta);
+                    _metadataReferences.Value.TryAdd(asm, meta);
                     newReferences.Value.Add(meta);
                 }
             }
@@ -299,12 +280,12 @@ public abstract class RoslynExpressionValidator
     private MetadataReference TryGetMetadataReference(Assembly assembly)
     {
         MetadataReference meta = null;
-        if (assembly != null && !_metadataReferenceDictionary.Value.TryGetValue(assembly, out meta))
+        if (assembly != null && !_metadataReferences.Value.TryGetValue(assembly, out meta))
         {
             meta = GetMetadataReferenceForAssembly(assembly);
             if (meta != null)
             {
-                _metadataReferenceDictionary.Value.TryAdd(assembly, meta);
+                _metadataReferences.Value.TryAdd(assembly, meta);
             }
         }
 
@@ -319,20 +300,20 @@ public abstract class RoslynExpressionValidator
         }
     }
 
-    private Dictionary<Assembly, MetadataReference> GetInitialMetadataReferences()
+    private ConcurrentDictionary<Assembly, MetadataReference> GetInitialMetadataReferences()
     {
-        var referenceCache = new Dictionary<Assembly, MetadataReference>();
+        var referenceCache = new ConcurrentDictionary<Assembly, MetadataReference>();
         foreach (var referencedAssembly in RequiredAssemblies)
         {
-            if (referencedAssembly == null || referenceCache.ContainsKey(referencedAssembly))
+            if (referencedAssembly is null || referenceCache.ContainsKey(referencedAssembly))
             {
                 continue;
             }
 
-            var mr = GetMetadataReferenceForAssembly(referencedAssembly);
-            if (mr != null)
+            var metadataReference = GetMetadataReferenceForAssembly(referencedAssembly);
+            if (metadataReference != null)
             {
-                referenceCache.Add(referencedAssembly, mr);
+                referenceCache.TryAdd(referencedAssembly, metadataReference);
             }
         }
 

--- a/src/UiPath.Workflow/Activities/VbExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/VbExpressionValidator.cs
@@ -42,7 +42,7 @@ public class VbExpressionValidator : RoslynExpressionValidator
         set => s_instance = value;
     }
 
-    protected override int IdentifierKind => (int) SyntaxKind.IdentifierName;
+    protected override int IdentifierKind => (int)SyntaxKind.IdentifierName;
 
     /// <summary>
     ///     Initializes the MetadataReference collection.
@@ -56,9 +56,9 @@ public class VbExpressionValidator : RoslynExpressionValidator
     ///     Assemblies to seed the collection.
     /// </param>
     public VbExpressionValidator(HashSet<Assembly> referencedAssemblies)
-        : base(referencedAssemblies != null 
-               ? new HashSet<Assembly>(s_defaultReferencedAssemblies.Union(referencedAssemblies)) 
-               : s_defaultReferencedAssemblies) 
+        : base(referencedAssemblies != null
+               ? new HashSet<Assembly>(s_defaultReferencedAssemblies.Union(referencedAssemblies))
+               : s_defaultReferencedAssemblies)
     { }
 
     protected override void UpdateCompilationUnit(ExpressionContainer expressionContainer)
@@ -74,7 +74,6 @@ public class VbExpressionValidator : RoslynExpressionValidator
                 mainTypeName: null,
                 globalImports: globalImports,
                 rootNamespace: "",
-                optionStrict: OptionStrict.On,
                 optionInfer: true,
                 optionExplicit: true,
                 optionCompareText: false,
@@ -83,9 +82,8 @@ public class VbExpressionValidator : RoslynExpressionValidator
                 checkOverflow: true,
                 xmlReferenceResolver: null,
                 sourceReferenceResolver: SourceFileResolver.Default,
-                concurrentBuild: !RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")),
-                assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default);
-            expressionContainer.CompilationUnit = DefaultCompilationUnit = 
+                concurrentBuild: !RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")));
+            expressionContainer.CompilationUnit = DefaultCompilationUnit =
                 VisualBasicCompilation.Create(assemblyName, null, metadataReferences, options);
         }
         else

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicDesignerHelper.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicDesignerHelper.cs
@@ -41,8 +41,15 @@ internal class VisualBasicHelper : JitCompilerHelper<VisualBasicHelper>
 
     protected override void Initialize(HashSet<AssemblyName> refAssemNames, HashSet<string> namespaceImportsNames)
     {
-        namespaceImportsNames.Add("Microsoft.VisualBasic");
+        AddDefaultNamespaces(namespaceImportsNames);
         base.Initialize(refAssemNames, namespaceImportsNames);
+    }
+
+    private static void AddDefaultNamespaces(HashSet<string> namespaceImportsNames)
+    {
+        namespaceImportsNames.Add("System");
+        namespaceImportsNames.Add("System.Linq.Expressions");
+        namespaceImportsNames.Add("Microsoft.VisualBasic");
     }
 
     public static Expression<Func<ActivityContext, T>> Compile<T>(string expressionText,

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicDesignerHelper.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicDesignerHelper.cs
@@ -41,15 +41,8 @@ internal class VisualBasicHelper : JitCompilerHelper<VisualBasicHelper>
 
     protected override void Initialize(HashSet<AssemblyName> refAssemNames, HashSet<string> namespaceImportsNames)
     {
-        AddDefaultNamespaces(namespaceImportsNames);
-        base.Initialize(refAssemNames, namespaceImportsNames);
-    }
-
-    private static void AddDefaultNamespaces(HashSet<string> namespaceImportsNames)
-    {
-        namespaceImportsNames.Add("System");
-        namespaceImportsNames.Add("System.Linq.Expressions");
         namespaceImportsNames.Add("Microsoft.VisualBasic");
+        base.Initialize(refAssemNames, namespaceImportsNames);
     }
 
     public static Expression<Func<ActivityContext, T>> Compile<T>(string expressionText,


### PR DESCRIPTION
There's a few takeways in this PR:
- removed `DesktopAssemblyIdentityComparer` from the compiler options as this was breaking compilation when the same assembly was provided twice but with different versions. This works in the current validation flow, so I expect the light validation should behave the same way.
- removed `OptionStrict.On` - it was causing all kinds of warnings in which we are not interested
- made `RoslynExpressionValidator` thread-safe. Studio Desktop will attempt to validate multiple files in parallel, so this needs to work
- added `_defaultNamespaces` in the `RoslynExpressionValidator` and included them part of the compilation. Without these namespaces, the compilation would fail with unknown type `Expression` errors. Since the `Expression` type is introduced by the validator for the purpose of validation/compilation, it makes sense for it to provide the required namespace.

In terms of testing, I've tested this by hand with the latest version of Studio with a couple larger projects I had at hand. 
