### PR TITLE
Clean and adapt for light validation use [STUD-61340]

### DIFF
--- a/src/Test/TestCases.Workflows/ExpressionTests.cs
+++ b/src/Test/TestCases.Workflows/ExpressionTests.cs
@@ -14,7 +14,6 @@ namespace TestCases.Workflows;
 public class ExpressionTests
 {
     private readonly ValidationSettings _skipCompilation = new() { SkipExpressionCompilation = true };
-    private readonly ValidationSettings _forceCache = new() { ForceExpressionCache = true };
     private readonly ValidationSettings _useValidator = new() { ForceExpressionCache = false };
 
     public static IEnumerable<object[]> ValidVbExpressions
@@ -146,7 +145,7 @@ public class ExpressionTests
         workflow.Activities.Add(writeLine);
         workflow.Variables.Add(new Variable<string>("b", "I'm a variable"));
 
-        ValidationResults validationResults = ActivityValidationServices.Validate(workflow, _forceCache);
+        ValidationResults validationResults = ActivityValidationServices.Validate(workflow, _useValidator);
         validationResults.Errors.Count.ShouldBe(1, string.Join("\n", validationResults.Errors.Select(e => e.Message)));
         validationResults.Errors[0].Message.ShouldContain("A null propagating operator cannot be converted into an expression tree.");
 

--- a/src/Test/TestCases.Workflows/TestXamls/TestHelper.cs
+++ b/src/Test/TestCases.Workflows/TestXamls/TestHelper.cs
@@ -21,10 +21,10 @@ namespace TestCases.Workflows
             return consoleOutputWriter.ToString();
         }
 
-        internal static Activity GetActivityFromXamlResource(TestXamls xamlName, bool compileExpressions = false)
+        internal static DynamicActivity GetActivityFromXamlResource(TestXamls xamlName, bool compileExpressions = false)
         {
             var xamlStream = GetXamlStream(xamlName);
-            return ActivityXamlServices.Load(xamlStream, new ActivityXamlServicesSettings { CompileExpressions = compileExpressions });
+            return ActivityXamlServices.Load(xamlStream, new ActivityXamlServicesSettings { CompileExpressions = compileExpressions }) as DynamicActivity;
         }
 
         public static Stream GetXamlStream(TestXamls xamlName)

--- a/src/Test/TestCases.Workflows/WF4Samples/Expressions.cs
+++ b/src/Test/TestCases.Workflows/WF4Samples/Expressions.cs
@@ -23,10 +23,11 @@ namespace TestCases.Workflows.WF4Samples
     public abstract class ExpressionsBase
     {
         protected abstract bool CompileExpressions { get; }
-        protected Activity GetActivityFromXamlResource(TestXamls xamlName) => TestHelper.GetActivityFromXamlResource(xamlName, CompileExpressions);
+        protected DynamicActivity GetActivityFromXamlResource(TestXamls xamlName) => TestHelper.GetActivityFromXamlResource(xamlName, CompileExpressions);
         protected Activity Compile(TestXamls xamlName)
         {
             var activity = GetActivityFromXamlResource(xamlName);
+            ActivityXamlServices.Compile(activity, new());
             Compiler.Run(activity);
             return activity;
         }
@@ -39,6 +40,7 @@ Salary statistics: minimum salary is $55000.00, maximum salary is $89000.00, ave
         public void SalaryCalculation()
         {
             var activity = GetActivityFromXamlResource(TestXamls.SalaryCalculation);
+            ActivityXamlServices.Compile(activity, new());
             TestHelper.InvokeWorkflow(activity).ShouldBe(CorrectOutput);
         }
 
@@ -55,6 +57,7 @@ Iterate ArrayList
         public void NonGenericForEach()
         {
             var activity = GetActivityFromXamlResource(TestXamls.NonGenericForEach);
+            ActivityXamlServices.Compile(activity, new());
             TestHelper.InvokeWorkflow(activity).ShouldBe(ForEachCorrectOutput);
         }
     }

--- a/src/Test/TestCases.Workflows/XamlTests.cs
+++ b/src/Test/TestCases.Workflows/XamlTests.cs
@@ -28,10 +28,11 @@ namespace TestCases.Workflows
         protected IStringDictionary InvokeWorkflow(string xamlString, IStringDictionary inputs = null)
         {
             var activity = Load(xamlString);
+            ActivityXamlServices.Compile(activity, new());
             return WorkflowInvoker.Invoke(activity, inputs ?? new StringDictionary());
         }
-        protected Activity Load(string xamlString) =>
-            ActivityXamlServices.Load(new StringReader(xamlString), new ActivityXamlServicesSettings { CompileExpressions = CompileExpressions });
+        protected DynamicActivity Load(string xamlString) =>
+            ActivityXamlServices.Load(new StringReader(xamlString), new ActivityXamlServicesSettings { CompileExpressions = CompileExpressions }) as DynamicActivity;
         public static IEnumerable<object[]> XamlNoInputs { get; } = new[]
         {
             new object[] { @"

--- a/src/UiPath.Workflow.Runtime/ExpressionUtilities.cs
+++ b/src/UiPath.Workflow.Runtime/ExpressionUtilities.cs
@@ -1928,13 +1928,4 @@ internal static class ExpressionUtilities
 
         return hasChanged;
     }
-
-    internal static Expression RewriteNonCompiledExpressionTree(LambdaExpression originalLambdaExpression)
-    {
-        ExpressionTreeRewriter expressionVisitor = new();
-        return expressionVisitor.Visit(Expression.Lambda(
-            typeof(Func<,>).MakeGenericType(typeof(ActivityContext), originalLambdaExpression.ReturnType),
-            originalLambdaExpression.Body,
-            new ParameterExpression[] { RuntimeContextParameter }));
-    }
 }

--- a/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
@@ -11,6 +11,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime;
 using System.Runtime.Collections;
 using System.Threading;
 using Microsoft.VisualBasic.Activities;
@@ -34,7 +35,9 @@ internal abstract class JitCompilerHelper
         typeof(CodeTypeDeclaration).Assembly, // System
         typeof(Expression).Assembly, // System.Core
         typeof(Conversions).Assembly, //Microsoft.VisualBasic.Core
-        typeof(Activity).Assembly // System.Activities
+        typeof(Activity).Assembly, // System.Activities
+        Assembly.Load("System.Runtime"), // System.Runtime.dll
+        Assembly.Load("netstandard") // netstandard.dll
     };
 
     private static readonly object s_typeReferenceCacheLock = new();

--- a/src/UiPath.Workflow/Activities/RoslynExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/RoslynExpressionValidator.cs
@@ -177,7 +177,11 @@ public abstract class RoslynExpressionValidator
         PrepValidation(expressionContainer);
 
         ModifyPreppedCompilationUnit(expressionContainer);
-        var diagnostics = expressionContainer.CompilationUnit.GetDiagnostics().Select(diagnostic =>
+        var diagnostics = expressionContainer
+            .CompilationUnit
+            .GetDiagnostics()
+            .Where(d=> d.Severity == DiagnosticSeverity.Error)
+            .Select(diagnostic =>
             new TextExpressionCompilerError
             {
                 SourceLineNumber = diagnostic.Location.GetMappedLineSpan().StartLinePosition.Line,

--- a/src/UiPath.Workflow/Activities/VbExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/VbExpressionValidator.cs
@@ -74,6 +74,7 @@ public class VbExpressionValidator : RoslynExpressionValidator
                 mainTypeName: null,
                 globalImports: globalImports,
                 rootNamespace: "",
+                optionStrict: OptionStrict.On,
                 optionInfer: true,
                 optionExplicit: true,
                 optionCompareText: false,

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpReference.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpReference.cs
@@ -49,6 +49,15 @@ public class CSharpReference<TResult> : CodeActivity<Location<TResult>>, ITextEx
     protected override void CacheMetadata(CodeActivityMetadata metadata)
     {
         _invoker = new CompiledExpressionInvoker(this, true, metadata);
+
+        if (metadata.Environment.IsValidating)
+        {
+            foreach (var validationError in VbExpressionValidator.Instance.Validate<TResult>(this, metadata.Environment,
+                         ExpressionText))
+            {
+                AddTempValidationError(validationError);
+            }
+        }
     }
 
     protected override Location<TResult> Execute(CodeActivityContext context)


### PR DESCRIPTION
`VBValue` and `VBReference` were compiling the expression and storing it as a lambda when calling `CacheMetadata`. While the reasons for this behavior might be forgotten, as long as `VbValue`, and `VbReference` (same as `CSharpValue` and `CSharpReference`) requires compilation, there is no reason to have this overhead in there.
The current implementation has a big performance impact in Studio, while running a workflow with 2000 expressions (which is quite common for clients). In this case, the RAM spikes up to more than 12gb, and it takes more than 2 minutes to validate the workflow, on a high-end machine (see https://uipath.atlassian.net/wiki/spaces/STUD/pages/87044198116/NetCore+validation+performance+improvements for a comparison).
Using the new validation, it takes roughly 5-7 seconds, and the RAM never spikes more than 600mb.

Moreover, since the `CSharp` and `VisualBasic` implementation both requires compilation now, there is no reason to have different implementations.