### PR TITLE
Support collectible assemblies for JIT compilation and fix memory leak

### DIFF
--- a/src/Test/TestCases.Workflows/TestUtils/Project.cs
+++ b/src/Test/TestCases.Workflows/TestUtils/Project.cs
@@ -7,6 +7,7 @@ using System.Activities;
 using System.Activities.ExpressionParser;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Loader;
 using System.Threading.Tasks;
 
 namespace TestCases.Workflows.TestUtils
@@ -30,7 +31,7 @@ namespace TestCases.Workflows.TestUtils
             _workspace.AddDocument(scriptProject.Id, className, SourceText.From(classCode));
             var compilation = await _workspace.CurrentSolution.Projects.First().GetCompilationAsync();
             //using var output = File.OpenWrite("Output.dll");
-            var results = ScriptingAotCompiler.BuildAssembly(compilation, className/*, output*/);
+            var results = ScriptingAotCompiler.BuildAssembly(compilation, className, AssemblyLoadContext.Default/*, output*/);
             if (results.HasErrors)
             {
                 throw new SourceExpressionException(results.ToString());

--- a/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
@@ -1293,6 +1293,19 @@ internal abstract class JitCompilerHelper<TLanguage> : JitCompilerHelper
         get => s_rawTreeCache ??= new HopperCache(RawTreeCacheMaxSize, false);
     }
 
+    public static void ClearRawTreeCache()
+    {
+        if (s_rawTreeCache == null)
+        {
+            return;
+        }
+
+        lock (s_rawTreeCacheLock)
+        {
+            s_rawTreeCache = new HopperCache(RawTreeCacheMaxSize, false);
+        }
+    }
+
     public string TextToCompile { get; }
 
     private HostedCompilerWrapper GetCachedHostedCompiler(HashSet<Assembly> assemblySet)

--- a/src/UiPath.Workflow/Activities/ScriptingAotCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingAotCompiler.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
@@ -46,10 +47,10 @@ public abstract class ScriptingAotCompiler : AheadOfTimeCompiler
 
     public static TextExpressionCompilerResults BuildAssembly(Compilation compilation)
     {
-        return BuildAssembly(compilation, compilation.ScriptClass.Name);
+        return BuildAssembly(compilation, compilation.ScriptClass.Name, AssemblyLoadContext.Default);
     }
 
-    public static TextExpressionCompilerResults BuildAssembly(Compilation compilation, string typeName,
+    public static TextExpressionCompilerResults BuildAssembly(Compilation compilation, string typeName, AssemblyLoadContext loadContext = null,
         Stream copy = null)
     {
         var results = GetCompilerResults(compilation);
@@ -66,7 +67,8 @@ public abstract class ScriptingAotCompiler : AheadOfTimeCompiler
             return results;
         }
 
-        results.ResultType = Assembly.Load(stream.GetBuffer()).GetType(typeName, true);
+        stream.Position = 0;
+        results.ResultType = loadContext.LoadFromStream(stream).GetType(typeName, true);
         if (copy != null)
         {
             stream.Position = 0;

--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -75,7 +75,7 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
         var finalCompilation = compilation.ReplaceSyntaxTree(syntaxTree, syntaxTree.WithChangedText(SourceText.From(
             CreateExpressionCode(types, names, expressionToCompile.Code))));
         
-        var collectibleAlc = new AssemblyLoadContext("ScriptingAot" + Guid.NewGuid(), true);
+        var collectibleAlc = new AssemblyLoadContext("ScriptingJit" + Guid.NewGuid(), true);
         collectibleAlc.Resolving += CollectibleAlc_Resolving;
         using var scope = collectibleAlc.EnterContextualReflection();
         

--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Runtime.Loader;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -73,7 +74,12 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
                 .Select(GetTypeName));
         var finalCompilation = compilation.ReplaceSyntaxTree(syntaxTree, syntaxTree.WithChangedText(SourceText.From(
             CreateExpressionCode(types, names, expressionToCompile.Code))));
-        var results = ScriptingAotCompiler.BuildAssembly(finalCompilation);
+        
+        var collectibleAlc = new AssemblyLoadContext("ScriptingAot" + Guid.NewGuid(), true);
+        collectibleAlc.Resolving += CollectibleAlc_Resolving;
+        using var scope = collectibleAlc.EnterContextualReflection();
+        
+        var results = ScriptingAotCompiler.BuildAssembly(finalCompilation, compilation.ScriptClass.Name, collectibleAlc);
         if (results.HasErrors)
         {
             var errorResults = new TextExpressionCompilerResults
@@ -86,6 +92,15 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
         }
 
         return (LambdaExpression)results.ResultType.GetMethod("CreateExpression")!.Invoke(null, null);
+    }
+
+    private Assembly CollectibleAlc_Resolving(AssemblyLoadContext loadContext, AssemblyName assemblyName)
+    {
+        var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.FullName == assemblyName.FullName);
+        if (assembly != null)
+            return assembly;
+
+        return loadContext.LoadFromAssemblyName(assemblyName);
     }
 
     public IEnumerable<string> GetIdentifiers(SyntaxTree syntaxTree)

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicDesignerHelper.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicDesignerHelper.cs
@@ -36,6 +36,8 @@ internal class VisualBasicHelper : JitCompilerHelper<VisualBasicHelper>
             {
                 compilerCache.Clear();
             }
+
+            ClearRawTreeCache();
         };
     }
 


### PR DESCRIPTION
Given the need for supporting collectible assemblies loaded in our designer, we should also support JIT compiling these (given a loaded or loadable compiled assembly).

Additionally, the `Assembly.Load` on a temporary assembly was leaking memory (consider that this was done for every expression, in each workflow).