### PR TITLE
Use newer Microsoft.CodeAnalysis version

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
     <PropertyGroup>
         <Version>6.0.0</Version>
+        <RoslynPackageVersion>4.5.0-2.22527.10</RoslynPackageVersion>
         <WarningsAsErrors>true</WarningsAsErrors>
         <UseWPF Condition="$(TargetFramework) == 'net6.0-windows'">true</UseWPF>
     </PropertyGroup>

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="Nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Test/TestCases.Workflows/TestCases.Workflows.csproj
+++ b/src/Test/TestCases.Workflows/TestCases.Workflows.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AgileObjects.ReadableExpressions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/UiPath.Workflow/UiPath.Workflow.csproj
+++ b/src/UiPath.Workflow/UiPath.Workflow.csproj
@@ -19,8 +19,8 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
         <PackageReference Include="ReflectionMagic" Version="4.1.0"/>
         <ProjectReference Include="..\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.Scripting.vbproj" PrivateAssets="All"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.0.1"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.1"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(RoslynPackageVersion)"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynPackageVersion)"/>
         <PackageReference Include="System.CodeDom" Version="6.0.0"/>
         <PackageReference Include="Nito.AsyncEx.Tasks" Version="5.1.2"/>
         <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="0.2.1-preview"/>

--- a/src/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.Scripting.vbproj
+++ b/src/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.Scripting.vbproj
@@ -24,8 +24,8 @@
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="$(RoslynPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(RoslynPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="VBScriptingResources.Designer.vb">


### PR DESCRIPTION
In order to leverage more modern C# code analysis features, we would like to use a new version of Microsoft.CodeAnalysis. See https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md for the documentation.

Tested with both C# and VB projects in UiPath Studio and Robot.