### PR TITLE
Expression improvements

### DIFF
--- a/src/UiPath.Workflow.Runtime/ExpressionUtilities.cs
+++ b/src/UiPath.Workflow.Runtime/ExpressionUtilities.cs
@@ -1928,4 +1928,13 @@ internal static class ExpressionUtilities
 
         return hasChanged;
     }
+
+    internal static Expression RewriteNonCompiledExpressionTree(LambdaExpression originalLambdaExpression)
+    {
+        ExpressionTreeRewriter expressionVisitor = new();
+        return expressionVisitor.Visit(Expression.Lambda(
+            typeof(Func<,>).MakeGenericType(typeof(ActivityContext), originalLambdaExpression.ReturnType),
+            originalLambdaExpression.Body,
+            new ParameterExpression[] { RuntimeContextParameter }));
+    }
 }

--- a/src/UiPath.Workflow.Runtime/Expressions/ITextExpression.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/ITextExpression.cs
@@ -23,4 +23,6 @@ public interface ITextExpression
     }
 
     Expression GetExpressionTree();
+
+    object ExecuteInContext(CodeActivityContext context);
 }

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpDesignerHelper.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpDesignerHelper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Activities;
 using System.Activities.ExpressionParser;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.VisualBasic.Activities;
 
@@ -15,8 +16,38 @@ internal class CSharpHelper : JitCompilerHelper<CSharpHelper>
     public CSharpHelper(string expressionText, HashSet<AssemblyName> refAssemNames,
         HashSet<string> namespaceImportsNames) : base(expressionText, refAssemNames, namespaceImportsNames) { }
 
+    private CSharpHelper(string expressionText) : base(expressionText) { }
+
     protected override JustInTimeCompiler CreateCompiler(HashSet<Assembly> references) => 
         new CSharpJitCompiler(references);
+
+    public static Expression<Func<ActivityContext, T>> Compile<T>(string expressionText,
+        CodeActivityPublicEnvironmentAccessor publicAccessor, bool isLocationExpression)
+    {
+        GetAllImportReferences(publicAccessor.ActivityMetadata.CurrentActivity, false, out var localNamespaces,
+            out var localAssemblies);
+        var helper = new CSharpHelper(expressionText);
+        var localReferenceAssemblies = new HashSet<AssemblyName>();
+        var localImports = new HashSet<string>(localNamespaces);
+        foreach (var assemblyReference in localAssemblies)
+        {
+            if (assemblyReference.Assembly != null)
+            {
+                // directly add the Assembly to the list
+                // so that we don't have to go through 
+                // the assembly resolution process
+                helper.ReferencedAssemblies ??= new HashSet<Assembly>();
+                helper.ReferencedAssemblies.Add(assemblyReference.Assembly);
+            }
+            else if (assemblyReference.AssemblyName != null)
+            {
+                localReferenceAssemblies.Add(assemblyReference.AssemblyName);
+            }
+        }
+
+        helper.Initialize(localReferenceAssemblies, localImports);
+        return helper.Compile<T>(publicAccessor, isLocationExpression);
+    }
 }
 
 internal class CSharpExpressionFactory<T> : ExpressionFactory

--- a/src/UiPath.Workflow/UiPath.Workflow.csproj
+++ b/src/UiPath.Workflow/UiPath.Workflow.csproj
@@ -30,6 +30,9 @@
         <ItemGroup>
             <BuildOutputInPackage Include="$(OutputPath)Microsoft.CodeAnalysis.VisualBasic.Scripting.*"/>
         </ItemGroup>
+		<ItemGroup Condition="'$(TargetFramework)' == 'net6.0' AND '$(Configuration)'=='Debug'">
+			<BuildOutputInPackage Include="$(OutputPath)System.Xaml.dll"/>
+		</ItemGroup>
     </Target>
     <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$(Configuration)=='Release'">
         <Exec Command="rd /S /Q %25UserProfile%25\.nuget\packages\$(TargetName)"/>


### PR DESCRIPTION
brought back a bit of the old code that was deleted in my previous PR, and more.
Exposed a way to execute an ITextExpression at a given context. This was done in Studio for VB and was lacking proper support for C#.
Also made sure GetExpressionTree will now return back the original expression even if the workflow is not compiled. This should help SWeb and Studio with certain functionalities that was relying on it.