### PR TITLE
Include fallback if an expression is not compiled

### DIFF
--- a/src/Test/TestCases.Workflows/WF4Samples/Expressions.cs
+++ b/src/Test/TestCases.Workflows/WF4Samples/Expressions.cs
@@ -27,7 +27,6 @@ namespace TestCases.Workflows.WF4Samples
         protected Activity Compile(TestXamls xamlName)
         {
             var activity = GetActivityFromXamlResource(xamlName);
-            ActivityXamlServices.Compile(activity, new());
             Compiler.Run(activity);
             return activity;
         }
@@ -40,7 +39,6 @@ Salary statistics: minimum salary is $55000.00, maximum salary is $89000.00, ave
         public void SalaryCalculation()
         {
             var activity = GetActivityFromXamlResource(TestXamls.SalaryCalculation);
-            ActivityXamlServices.Compile(activity, new());
             TestHelper.InvokeWorkflow(activity).ShouldBe(CorrectOutput);
         }
 
@@ -57,7 +55,6 @@ Iterate ArrayList
         public void NonGenericForEach()
         {
             var activity = GetActivityFromXamlResource(TestXamls.NonGenericForEach);
-            ActivityXamlServices.Compile(activity, new());
             TestHelper.InvokeWorkflow(activity).ShouldBe(ForEachCorrectOutput);
         }
     }

--- a/src/Test/TestCases.Workflows/XamlTests.cs
+++ b/src/Test/TestCases.Workflows/XamlTests.cs
@@ -28,11 +28,10 @@ namespace TestCases.Workflows
         protected IStringDictionary InvokeWorkflow(string xamlString, IStringDictionary inputs = null)
         {
             var activity = Load(xamlString);
-            ActivityXamlServices.Compile(activity, new());
             return WorkflowInvoker.Invoke(activity, inputs ?? new StringDictionary());
         }
-        protected DynamicActivity Load(string xamlString) =>
-            ActivityXamlServices.Load(new StringReader(xamlString), new ActivityXamlServicesSettings { CompileExpressions = CompileExpressions }) as DynamicActivity;
+        protected Activity Load(string xamlString) =>
+            ActivityXamlServices.Load(new StringReader(xamlString), new ActivityXamlServicesSettings { CompileExpressions = CompileExpressions });
         public static IEnumerable<object[]> XamlNoInputs { get; } = new[]
         {
             new object[] { @"

--- a/src/UiPath.Workflow.Runtime/Expressions/CompiledExpressionInvoker.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/CompiledExpressionInvoker.cs
@@ -108,6 +108,27 @@ public class CompiledExpressionInvoker
         return value;
     }
 
+    internal bool IsExpressionCompiled(ActivityContext activityContext)
+    {
+        if (activityContext == null)
+        {
+            throw FxTrace.Exception.ArgumentNull(nameof(activityContext));
+        }
+
+        if (_compiledRoot == null || _expressionId < 0)
+        {
+            if (!TryGetCompiledExpressionRoot(_expressionActivity, _metadataRoot, out _compiledRoot) ||
+                !CanExecuteExpression(_compiledRoot, out _expressionId))
+            {
+                if (!TryGetCurrentCompiledExpressionRoot(activityContext, out _compiledRoot, out _expressionId))
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     //
     // Internal helper to find the correct ICER for a given expression.
     internal static bool TryGetCompiledExpressionRoot(Activity expression, Activity target, out ICompiledExpressionRoot compiledExpressionRoot)


### PR DESCRIPTION
If an expression is not compiled, compile it in Execute method and run it. This is so we do not break old workflows, or non-compliant activities that use VisualBasicValue / Reference in places other than on public, browsable properties of an activity.