### PR TITLE
Update README.md - Remove experimental status description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # CoreWF
 
-A port of the Windows Workflow Foundation (WF) runtime to .NET 6. This project is still in the experimental phase. It
+A port of the Windows Workflow Foundation (WF) runtime to .NET 6. It
 is [licensed](LICENSE) under the MIT License.
 
 __This is not an official Microsoft release of WF on .NET 6. CoreWF is a derivative work of Microsoft's copyrighted


### PR DESCRIPTION
With CoreWF being used in Studio for a couple of years now, I think we can safely remove the 'experimental' label. What do you think?