### PR TITLE
Let ScriptingJitCompiler resolve assemblies, which already exist in AppDomain

### DIFF
--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -97,9 +97,8 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
     private Assembly CollectibleAlc_Resolving(AssemblyLoadContext loadContext, AssemblyName assemblyName)
     {
         var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.FullName == assemblyName.FullName);
-        if (assembly != null)
-            return assembly;
-
+        if (assembly is not null && !string.IsNullOrWhiteSpace(assembly.Location))
+            return loadContext.LoadFromAssemblyPath(assembly.Location);
         return loadContext.LoadFromAssemblyName(assemblyName);
     }
 


### PR DESCRIPTION
Sometimes there is a need to compile expressions, which require references to assemblies, which do exist in AppDomain.CurrentDomain, but not in current AssemblyLoadContext. In such a case current implementation is looking for such an assembly in AppDomain.CurrentDomain, but doesn't load it. This causes exceptions when last line of ScriptingJitCompiler.CompileExpression ("GetMethod("CreateExpression")!.Invoke") is called. 
According to https://learn.microsoft.com/en-us/dotnet/api/System.Runtime.Loader.AssemblyLoadContext?view=net-6.0 (section "Application usage") AssemblyLoadContext.Resolving is a "second chance to resolve the assembly" after call to  AssemblyLoadContext.Load, so it's logical, it should do the same (i.e. not  only resolve, but also load). Current implementation resolves and loads when assembly isn't found in AppDomain.CurrentDomain, but only resolves otherwise. 
This fix makes attempt to load always.
