### PR TITLE
Missing references for C# validation

### DIFF
--- a/src/UiPath.Workflow/Activities/CsExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/CsExpressionValidator.cs
@@ -89,14 +89,9 @@ public class CsExpressionValidator : RoslynExpressionValidator
         else
         {
             var options = DefaultCompilationUnit.Options as CSharpCompilationOptions;
-            var compilation = DefaultCompilationUnit.WithOptions(
-                options.WithUsings(expressionContainer.ExpressionToValidate.ImportedNamespaces));
-
-            var missingReferences = compilation.References.Except(metadataReferences);
-            expressionContainer.CompilationUnit =
-                missingReferences.Any()
-                ? compilation.AddReferences(missingReferences)
-                : compilation;
+            expressionContainer.CompilationUnit = DefaultCompilationUnit
+                .WithOptions(options.WithUsings(expressionContainer.ExpressionToValidate.ImportedNamespaces))
+                .WithReferences(metadataReferences);
         }
     }
 


### PR DESCRIPTION
Validating an expression first, then another one that needs more assemblies than the first one, would cause an exception, because the assemblies were not set correctly for each expression validated.

This only happens on C# validator, as VB validator is already set correct.
I aligned their functionality, and added tests for both VB and C# to make sure they are both covered.