### PR TITLE
Fix vb issue with identifiers uniqueness

### DIFF
--- a/src/Test/TestCases.Workflows/ExpressionTests.cs
+++ b/src/Test/TestCases.Workflows/ExpressionTests.cs
@@ -235,6 +235,18 @@ public class ExpressionTests
     }
 
     [Fact]
+    public void VbValue_IdentifiersComparerOrdinalIgnoreCase()
+    {
+        var root = new Sequence();
+        root.Variables.Add(new Variable<List<object>>("count"));
+        root.Activities.Add(new WriteLine { Text = new InArgument<string>(new VisualBasicValue<string>("count.Count.ToString")) });
+
+        var result = ActivityValidationServices.Validate(root, _useValidator);
+
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void CSValue_ShowsValidationError()
     {
         var activity = new WriteLine { Text = new InArgument<string>(new CSharpValue<string>("var1")) };

--- a/src/UiPath.Workflow/Activities/RoslynExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/RoslynExpressionValidator.cs
@@ -28,6 +28,7 @@ public abstract class RoslynExpressionValidator
     private const string Comma = ", ";
     private readonly Lazy<ConcurrentDictionary<Assembly, MetadataReference>> _metadataReferences;
     private readonly object _lockRequiredAssemblies = new();
+    protected virtual StringComparer IdentifierNameComparer => StringComparer.Ordinal;
 
     /// <summary>
     ///     Initializes the MetadataReference collection.
@@ -288,7 +289,7 @@ public abstract class RoslynExpressionValidator
     {
         var syntaxTree = expressionContainer.CompilationUnit.SyntaxTrees.First();
         var identifiers = syntaxTree.GetRoot().DescendantNodesAndSelf().Where(n => n.RawKind == IdentifierKind)
-                                    .Select(n => n.ToString()).Distinct();
+                                    .Select(n => n.ToString()).Distinct(IdentifierNameComparer);
         var resolvedIdentifiers =
             identifiers
                 .Select(name => (Name: name, Type: expressionContainer.ExpressionToValidate.VariableTypeGetter(name)))

--- a/src/UiPath.Workflow/Activities/VbExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/VbExpressionValidator.cs
@@ -22,6 +22,7 @@ public class VbExpressionValidator : RoslynExpressionValidator
 
     private static readonly VisualBasicParseOptions s_vbScriptParseOptions =
         new(kind: SourceCodeKind.Script, languageVersion: LanguageVersion.Latest);
+    protected override StringComparer IdentifierNameComparer => StringComparer.OrdinalIgnoreCase;
 
     private static readonly HashSet<Assembly> s_defaultReferencedAssemblies = new()
     {


### PR DESCRIPTION
The issue comes when you have a variable with the same name as a method, i.e. variable name: count, of type `List<Object>` and writing the following expression: `count.Count.ToString`. Aligned the behavior to be the same as ScriptingJitCompiler, so VBValidator will treat identifiers unique ignoring case. CSValidator works as expected.