### PR TITLE
Fix RoslynValidator to check if CSReference / VBReference can be assigned to [STUD-63401]

### DIFF
--- a/src/Perf/CoreWf.Benchmarks/Program.cs
+++ b/src/Perf/CoreWf.Benchmarks/Program.cs
@@ -2,7 +2,7 @@
 using CoreWf.Benchmarks;
 
 #if RELEASE
-BenchmarkRunner.Run<Expressions>();
+BenchmarkRunner.Run<RoslynValidatorReferenceVsNonReference>();
 #else
 var e = new Expressions();
 try

--- a/src/Perf/CoreWf.Benchmarks/RoslynValidatorReferenceVsNonReference.cs
+++ b/src/Perf/CoreWf.Benchmarks/RoslynValidatorReferenceVsNonReference.cs
@@ -1,0 +1,51 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.CSharp.Activities;
+using Microsoft.VisualBasic.Activities;
+using System.Activities.Validation;
+
+namespace CoreWf.Benchmarks;
+
+public class RoslynValidatorReferenceVsNonReference
+{
+    private readonly ValidationSettings _useValidator = new() { ForceExpressionCache = false };
+
+    [Benchmark]
+    public void TestVBValue()
+    {
+        for (var i = 0; i < 1000; i++)
+        {
+            var activity = new VisualBasicValue<bool>("Environment.Is64BitOperatingSystem");
+            ActivityValidationServices.Validate(activity, _useValidator);
+        }
+    }
+
+    [Benchmark]
+    public void TestVBReference()
+    {
+        for (var i = 0; i < 1000; i++)
+        {
+            var activity = new VisualBasicReference<bool>("Environment.Is64BitOperatingSystem");
+            ActivityValidationServices.Validate(activity, _useValidator);
+        }
+    }
+
+    [Benchmark]
+    public void TestCSReference()
+    {
+        for (var i = 0; i < 1000; i++)
+        {
+            var activity = new CSharpReference<bool>("Environment.Is64BitOperatingSystem");
+            ActivityValidationServices.Validate(activity, _useValidator);
+        }
+    }
+
+    [Benchmark]
+    public void TestCSValue()
+    {
+        for (var i = 0; i < 1000; i++)
+        {
+            var activity = new CSharpValue<bool>("Environment.Is64BitOperatingSystem");
+            ActivityValidationServices.Validate(activity, _useValidator);
+        }
+    }
+}

--- a/src/UiPath.Workflow/Activities/ExpressionContainer.cs
+++ b/src/UiPath.Workflow/Activities/ExpressionContainer.cs
@@ -44,4 +44,10 @@ public class ExpressionContainer
     ///     Diagnostics reported by validating the expression.
     /// </summary>
     public IEnumerable<TextExpressionCompilerError> Diagnostics { get; set; }
+
+    /// <summary>
+    ///     Set to true if the activity is a location / reference
+    ///     so extra checks must be made on it
+    /// </summary>
+    public bool IsLocation { get; set; }
 }

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpReference.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpReference.cs
@@ -32,7 +32,7 @@ public class CSharpReference<TResult> : CodeActivity<Location<TResult>>, ITextEx
     protected override void CacheMetadata(CodeActivityMetadata metadata)
     {
         _invoker = new CompiledExpressionInvoker(this, true, metadata);
-        CsExpressionValidator.Instance.TryValidate<TResult>(this, metadata, ExpressionText);
+        CsExpressionValidator.Instance.TryValidate<TResult>(this, metadata, ExpressionText, true);
     }
 
     protected override Location<TResult> Execute(CodeActivityContext context) => (Location<TResult>)_invoker.InvokeExpression(context);

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicReference.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicReference.cs
@@ -84,7 +84,7 @@ public sealed class VisualBasicReference<TResult> : CodeActivity<Location<TResul
     {
         _expressionTree = null;
         _invoker = new CompiledExpressionInvoker(this, true, metadata);
-        if (VbExpressionValidator.Instance.TryValidate<TResult>(this, metadata, ExpressionText))
+        if (VbExpressionValidator.Instance.TryValidate<TResult>(this, metadata, ExpressionText, true))
         {
             return;
         }


### PR DESCRIPTION
### This PR is intended to change only design time validation behavior

The problem:
RoslynValidator will not validate if a location expression is readonly or not.
Nor does the old validator. Some extra code does the check, `ExpressionUtilities.IsLocation`. This extra check cannot be used with RoslynValidator

The solution
Adapt RoslynValidator code to make sure location is not readonly.

Benefits of this:
- Better checking if the expression is readony than the `ExpressionUtilities.IsLocation`
- Benchmarking of the current idea shows no degrading when comparing a Value to a Reference (old vs new). Considering we cut the `ExpressionUtilities.IsLocation` from equation here, we should have a slight better performance.

Tested with 1000 iterations, here are the results
![image](https://user-images.githubusercontent.com/49864209/235117447-1a77e7fe-e60d-4661-85ea-79a7b60988ea.png)

Side note: improved error message by trimming the useless first part of the error message 
old: `(2,6): error BC1234: The error is xyz` 
new: `BC1234: The error is xyz`
