### PR TITLE
Fixed validation of expressions with more than 16 arguments

### DIFF
--- a/src/Test/TestCases.Workflows/ExpressionTests.cs
+++ b/src/Test/TestCases.Workflows/ExpressionTests.cs
@@ -395,4 +395,33 @@ public class ExpressionTests
         var result = ActivityValidationServices.Validate(dy, _useValidator);
         result.Errors.ShouldBeEmpty();
     }
+
+
+    [Fact]
+    public void VBRoslynValidator_ValidatesMoreThan16Arguments()
+    {
+        var sequence = new Sequence();
+        for (int i = 0; i < 20; i++)
+        {
+            sequence.Variables.Add(new Variable<string>($"var{i}"));
+        }
+        var testActivity = new VisualBasicValue<string[]>(string.Format("{{{0}}}", string.Join(", ", Enumerable.Range(0, 20).Select(r => $"var{r}"))));
+        sequence.Activities.Add(testActivity);
+        var result = ActivityValidationServices.Validate(sequence, _useValidator);
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CSRoslynValidator_ValidatesMoreThan16Arguments()
+    {
+        var sequence = new Sequence();
+        for (int i = 0; i < 20; i++)
+        {
+            sequence.Variables.Add(new Variable<string>($"var{i}"));
+        }
+        var testActivity = new CSharpValue<string[]>(string.Format("new [] {{{0}}}", string.Join(", ", Enumerable.Range(0, 20).Select(r => $"var{r}"))));
+        sequence.Activities.Add(testActivity);
+        var result = ActivityValidationServices.Validate(sequence, _useValidator);
+        result.Errors.ShouldBeEmpty();
+    }
 }

--- a/src/UiPath.Workflow/Activities/CsExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/CsExpressionValidator.cs
@@ -49,7 +49,7 @@ public class CsExpressionValidator : RoslynExpressionValidator
         set => s_instance = value;
     }
 
-    protected override int IdentifierKind => (int)SyntaxKind.IdentifierName;
+    protected override CompilerHelper CompilerHelper { get; } = new CSharpCompilerHelper();
 
     /// <summary>
     ///     Initializes the MetadataReference collection.
@@ -98,7 +98,7 @@ public class CsExpressionValidator : RoslynExpressionValidator
     }
 
     protected override string CreateValueCode(string types, string names, string code)
-     => string.Format(_valueValidationTemplate, types, names, code);
+     => CompilerHelper.CreateExpressionCode(types, names, code);
 
     protected override string CreateReferenceCode(string types, string names, string code)
     {

--- a/src/UiPath.Workflow/Activities/RoslynExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/RoslynExpressionValidator.cs
@@ -31,8 +31,8 @@ public abstract class RoslynExpressionValidator
     private readonly object _lockRequiredAssemblies = new();
 
     protected const string Comma = ", ";
-    protected virtual StringComparer IdentifierNameComparer => StringComparer.Ordinal;
 
+    protected abstract CompilerHelper CompilerHelper { get; }
     /// <summary>
     ///     Initializes the MetadataReference collection.
     /// </summary>
@@ -58,11 +58,6 @@ public abstract class RoslynExpressionValidator
     ///     to add more assemblies.
     /// </summary>
     protected IReadOnlySet<Assembly> RequiredAssemblies { get; private set; }
-
-    /// <summary>
-    ///     The kind of identifier to look for in the syntax tree as variables that need to be resolved for the expression.
-    /// </summary>
-    protected abstract int IdentifierKind { get; }
 
     /// <summary>
     ///     Adds an assembly to the <see cref="RequiredAssemblies"/> set.
@@ -314,8 +309,8 @@ public abstract class RoslynExpressionValidator
     private void PrepValidation(ExpressionContainer expressionContainer)
     {
         var syntaxTree = expressionContainer.CompilationUnit.SyntaxTrees.First();
-        var identifiers = syntaxTree.GetRoot().DescendantNodesAndSelf().Where(n => n.RawKind == IdentifierKind)
-                                    .Select(n => n.ToString()).Distinct(IdentifierNameComparer);
+        var identifiers = syntaxTree.GetRoot().DescendantNodesAndSelf().Where(n => n.RawKind == CompilerHelper.IdentifierKind)
+                                    .Select(n => n.ToString()).Distinct(CompilerHelper.IdentifierNameComparer);
         var resolvedIdentifiers =
             identifiers
                 .Select(name => (Name: name, Type: expressionContainer.ExpressionToValidate.VariableTypeGetter(name)))

--- a/src/UiPath.Workflow/Activities/Utils/CSharpCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CSharpCompilerHelper.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Text;
+using System.Threading;
+
+namespace System.Activities
+{
+    public sealed class CSharpCompilerHelper : CompilerHelper
+    {
+        static int crt = 0;
+
+        public override int IdentifierKind => (int)SyntaxKind.IdentifierName;
+
+        public override StringComparer IdentifierNameComparer => StringComparer.Ordinal;
+
+        public override string CreateExpressionCode(string types, string names, string code)
+        {
+            var arrayType = types.Split(",");
+            if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
+                return $"public static Expression<Func<{types}>> CreateExpression() => ({names}) => {code};";
+
+
+            var (myDelegate, name) = DefineDelegate(types);
+            return $"{myDelegate} \n public static Expression<{name}<{types}>> CreateExpression() => ({names}) => {code};";
+        }
+
+        private static (string, string) DefineDelegate(string types)
+        {
+            var crtValue = Interlocked.Add(ref crt, 1);
+            var arrayType = types.Split(",");
+            var part1 = new StringBuilder();
+            var part2 = new StringBuilder();
+
+            for (var i = 0; i < arrayType.Length - 1; i++)
+            {
+                part1.Append($"in T{i}, ");
+                part2.Append($" T{i} arg{i},");
+            }
+            part2.Remove(part2.Length - 1, 1);
+            var name = $"Func{crtValue}";
+            return ($"public delegate TResult {name}<{part1} out TResult>({part2});", name);
+        }
+    }
+}

--- a/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace System.Activities
+{
+    public abstract class CompilerHelper
+    {
+        public abstract string CreateExpressionCode(string types, string names, string code);
+
+        public abstract StringComparer IdentifierNameComparer { get; }
+
+        public abstract int IdentifierKind { get; }
+    }
+}

--- a/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.CodeAnalysis.VisualBasic;
+using System;
+using System.Text;
+using System.Threading;
+
+namespace System.Activities
+{
+    public sealed class VBCompilerHelper : CompilerHelper
+    {
+        static int crt = 0;
+
+        public override int IdentifierKind => (int)SyntaxKind.IdentifierName;
+
+        public override StringComparer IdentifierNameComparer => StringComparer.OrdinalIgnoreCase;
+
+        public override string CreateExpressionCode(string types, string names, string code)
+        {
+            var arrayType = types.Split(",");
+            if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
+                return $"Public Shared Function CreateExpression() As Expression(Of Func(Of {types}))\nReturn Function({names}) ({code})\nEnd Function";
+
+            var (myDelegate, name) = DefineDelegate(types);
+            return $"{myDelegate} \n Public Shared Function CreateExpression() As Expression(Of {name}(Of {types}))\nReturn Function({names}) ({code})\nEnd Function";
+        }
+
+        private static (string, string) DefineDelegate(string types)
+        {
+            var crtValue = Interlocked.Add(ref crt, 1);
+
+            var arrayType = types.Split(",");
+            var part1 = new StringBuilder();
+            var part2 = new StringBuilder();
+
+            for (var i = 0; i < arrayType.Length - 1; i++)
+            {
+                part1.Append($" In T{i},");
+                part2.Append($" ByVal arg as T{i},");
+            }
+            part2.Remove(part2.Length - 1, 1);
+
+            var name = $"Func{crtValue}";
+            return ($"Public Delegate Function {name}(Of {part1} Out TResult)({part2}) As TResult", name);
+        }
+    }
+}

--- a/src/UiPath.Workflow/Activities/VbExpressionValidator.cs
+++ b/src/UiPath.Workflow/Activities/VbExpressionValidator.cs
@@ -25,7 +25,6 @@ public class VbExpressionValidator : RoslynExpressionValidator
 
     private static readonly VisualBasicParseOptions s_vbScriptParseOptions =
         new(kind: SourceCodeKind.Script, languageVersion: LanguageVersion.Latest);
-    protected override StringComparer IdentifierNameComparer => StringComparer.OrdinalIgnoreCase;
 
     private static readonly HashSet<Assembly> s_defaultReferencedAssemblies = new()
     {
@@ -46,7 +45,7 @@ public class VbExpressionValidator : RoslynExpressionValidator
         set => s_instance = value;
     }
 
-    protected override int IdentifierKind => (int)SyntaxKind.IdentifierName;
+    protected override CompilerHelper CompilerHelper { get; } = new VBCompilerHelper();
 
     /// <summary>
     ///     Initializes the MetadataReference collection.
@@ -100,7 +99,7 @@ public class VbExpressionValidator : RoslynExpressionValidator
     }
 
     protected override string CreateValueCode(string types, string names, string code)
-     => string.Format(_valueValidationTemplate, types, names, code);
+     => CompilerHelper.CreateExpressionCode(types, names, code);
 
     protected override string CreateReferenceCode(string types, string names, string code)
     {


### PR DESCRIPTION
This was already fixed for JitCompiler ([here](https://github.com/UiPath/CoreWF/pull/213/files)), but RoslynValidator was not in sync.
Moved code to a common place for both.
