### PR TITLE
[DRAFT] Added DesignValidationServices

### DIFF
--- a/src/Perf/CoreWf.Benchmarks/Expressions.cs
+++ b/src/Perf/CoreWf.Benchmarks/Expressions.cs
@@ -16,7 +16,6 @@ public class Expressions
     private readonly Activity[] _vbSingleExpr100;
     private readonly Activity[] _cs400Stmts;
     private int _activityIndex;
-    private readonly ValidationSettings _useValidator = new() { ForceExpressionCache = false };
 
     public Expressions()
     {
@@ -54,7 +53,7 @@ public class Expressions
     {
         var activity = _vb100Stmts[_activityIndex];
         _activityIndex = (_activityIndex + 1) % _vb100Stmts.Length;
-        _ = ActivityValidationServices.Validate(activity, _useValidator);
+        _ = DesignValidationServices.Validate(activity);
     }
 
     [Benchmark]
@@ -62,7 +61,7 @@ public class Expressions
     {
         var activity = _vb400Stmts[_activityIndex];
         _activityIndex = (_activityIndex + 1) % _vb400Stmts.Length;
-        _ = ActivityValidationServices.Validate(activity, _useValidator);
+        _ = DesignValidationServices.Validate(activity);
     }
 
     //[Benchmark]
@@ -70,7 +69,7 @@ public class Expressions
     {
         var activity = _vbSingleExpr100[_activityIndex];
         _activityIndex = (_activityIndex + 1) % _vbSingleExpr100.Length;
-        _ = ActivityValidationServices.Validate(activity, _useValidator);
+        _ = DesignValidationServices.Validate(activity);
     }
 
     [Benchmark]
@@ -110,7 +109,7 @@ public class Expressions
     {
         var activity = _cs400Stmts[_activityIndex];
         _activityIndex = (_activityIndex + 1) % _cs400Stmts.Length;
-        _ = ActivityValidationServices.Validate(activity, _useValidator);
+        _ = DesignValidationServices.Validate(activity);
     }
 
     private static Activity GenerateManyExpressionsWorkflow(int startExprNum, int numExpressions, string language = "VB")

--- a/src/Perf/CoreWf.Benchmarks/RoslynValidatorReferenceVsNonReference.cs
+++ b/src/Perf/CoreWf.Benchmarks/RoslynValidatorReferenceVsNonReference.cs
@@ -7,7 +7,6 @@ namespace CoreWf.Benchmarks;
 
 public class RoslynValidatorReferenceVsNonReference
 {
-    private readonly ValidationSettings _useValidator = new() { ForceExpressionCache = false };
 
     [Benchmark]
     public void TestVBValue()
@@ -15,7 +14,7 @@ public class RoslynValidatorReferenceVsNonReference
         for (var i = 0; i < 1000; i++)
         {
             var activity = new VisualBasicValue<bool>("Environment.Is64BitOperatingSystem");
-            ActivityValidationServices.Validate(activity, _useValidator);
+            DesignValidationServices.Validate(activity);
         }
     }
 
@@ -25,7 +24,7 @@ public class RoslynValidatorReferenceVsNonReference
         for (var i = 0; i < 1000; i++)
         {
             var activity = new VisualBasicReference<bool>("Environment.Is64BitOperatingSystem");
-            ActivityValidationServices.Validate(activity, _useValidator);
+            DesignValidationServices.Validate(activity);
         }
     }
 
@@ -35,7 +34,7 @@ public class RoslynValidatorReferenceVsNonReference
         for (var i = 0; i < 1000; i++)
         {
             var activity = new CSharpReference<bool>("Environment.Is64BitOperatingSystem");
-            ActivityValidationServices.Validate(activity, _useValidator);
+            DesignValidationServices.Validate(activity);
         }
     }
 
@@ -45,7 +44,7 @@ public class RoslynValidatorReferenceVsNonReference
         for (var i = 0; i < 1000; i++)
         {
             var activity = new CSharpValue<bool>("Environment.Is64BitOperatingSystem");
-            ActivityValidationServices.Validate(activity, _useValidator);
+            DesignValidationServices.Validate(activity);
         }
     }
 }

--- a/src/Test/TestCases.Workflows/Compiler.cs
+++ b/src/Test/TestCases.Workflows/Compiler.cs
@@ -9,13 +9,14 @@ using System.Linq.Expressions;
 using System.Reflection;
 namespace TestCases.Workflows
 {
-    using static ExpressionUtilities;
     using static Expression;
+    using static ExpressionUtilities;
+
     static class Compiler
     {
         public static void Run(Activity root)
         {
-            ActivityValidationServices.Validate(root, new() { SkipValidatingRootConfiguration = true, ForceExpressionCache = true });
+            ActivityValidationServices.Validate(root, new() { SkipValidatingRootConfiguration = true });
             foreach (var activity in root.GetChildren().ToArray())
             {
                 foreach (var argument in activity.RuntimeArguments)
@@ -132,7 +133,7 @@ namespace TestCases.Workflows
             return isLocation;
         }
         private static string LocationName(this MethodCallExpression node) => ((LocationReference)((ConstantExpression)node.Arguments[0]).Value).Name;
-        static IEnumerable<Activity> GetChildren(this Activity root) => 
+        static IEnumerable<Activity> GetChildren(this Activity root) =>
             new[] { root }.Concat(WorkflowInspectionServices.GetActivities(root).SelectMany(a => a.GetChildren()));
         static readonly MethodInfo ActivityContextGetValue = typeof(ActivityContext).GetMethod(nameof(ActivityContext.GetValue), new Type[] { typeof(string) });
     }

--- a/src/Test/TestCases.Workflows/DesignValidationTests.cs
+++ b/src/Test/TestCases.Workflows/DesignValidationTests.cs
@@ -1,0 +1,441 @@
+﻿using CustomTestObjects;
+using Microsoft.CSharp.Activities;
+using Microsoft.VisualBasic.Activities;
+using Shouldly;
+using System.Activities;
+using System.Activities.Expressions;
+using System.Activities.Statements;
+using System.Activities.Validation;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace TestCases.Workflows;
+
+public class DesignValidationTests
+{
+    public static IEnumerable<object[]> ValidVbExpressions
+    {
+        get
+        {
+            yield return new object[] { @$"String.Concat(""alpha "", ""beta "", 1)" };
+            yield return new object[] { @$"String.Concat(""alpha "", v, ""beta "", 1)" };
+            yield return new object[] { @$"String.Concat(""alpha "", l(0), ""beta "", 1)" };
+            yield return new object[] { @$"String.Concat(""alpha "", d(""gamma""), ""beta "", 1)" };
+            yield return new object[] { @"[Enum].Parse(GetType(ArgumentDirection), ""In"").ToString()" };
+            yield return new object[] { "GetType(Activities.VisualBasicSettings).Name" };
+        }
+    }
+
+    public static IEnumerable<object[]> ValidCsExpressions
+    {
+        get
+        {
+            yield return new object[] { $@"string.Join(',', ""alpha"", 1, ""beta"")" };
+            yield return new object[] { $@"string.Join(',', ""alpha"", v, 1, ""beta"")" };
+            yield return new object[] { $@"string.Join(',', ""alpha"", l[0], 1, ""beta"")" };
+            yield return new object[] { $@"string.Join(',', ""alpha"", d[""gamma""], 1, ""beta"")" };
+        }
+    }
+
+    static DesignValidationTests()
+    {
+        // There's no programmatic way (that I know of) to add assembly references when creating workflows like in these tests.
+        // Adding the custom assembly directly to the expression validator to simulate XAML reference.
+        // The null is for testing purposes.
+        DesignVBExpressionValidator.Instance = new DesignVBExpressionValidator(new() { typeof(ClassWithCollectionProperties).Assembly, null });
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidVbExpressions))]
+    public void Vb_Valid(string expr)
+    {
+        VisualBasicValue<string> vbv = new(expr);
+        WriteLine writeLine = new();
+        writeLine.Text = new InArgument<string>(vbv);
+        Sequence workflow = new();
+        workflow.Activities.Add(writeLine);
+        workflow.Variables.Add(new Variable<string>("v", "I'm a variable"));
+        workflow.Variables.Add(new Variable<List<string>>("l"));
+        workflow.Variables.Add(new Variable<Dictionary<string, List<string>>>("d"));
+
+        ValidationResults validationResults = DesignValidationServices.Validate(workflow);
+        validationResults.Errors.Count.ShouldBe(0, string.Join("\n", validationResults.Errors.Select(e => e.Message)));
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidCsExpressions))]
+    public void Cs_Valid(string expr)
+    {
+        CSharpValue<string> csv = new(expr);
+        WriteLine writeLine = new();
+        writeLine.Text = new InArgument<string>(csv);
+        Sequence workflow = new();
+        workflow.Activities.Add(writeLine);
+        workflow.Variables.Add(new Variable<string>("v", "I'm a variable"));
+        workflow.Variables.Add(new Variable<List<string>>("l"));
+        workflow.Variables.Add(new Variable<Dictionary<string, List<string>>>("d"));
+
+        ValidationResults validationResults = DesignValidationServices.Validate(workflow);
+        validationResults.Errors.Count.ShouldBe(0, string.Join("\n", validationResults.Errors.Select(e => e.Message)));
+    }
+
+    [Fact]
+    public void Vb_InvalidExpression_Basic()
+    {
+        VisualBasicValue<string> vbv = new(@$"String.Concat(""alpha "", b, ""beta "", 1)");
+        WriteLine writeLine = new();
+        writeLine.Text = new InArgument<string>(vbv);
+        Sequence workflow = new();
+        workflow.Activities.Add(writeLine);
+
+        ValidationResults validationResults = DesignValidationServices.Validate(workflow);
+        validationResults.Errors.Count.ShouldBe(1, string.Join("\n", validationResults.Errors.Select(e => e.Message)));
+    }
+
+    [Fact]
+    public void Cs_InvalidExpression_Basic()
+    {
+        CSharpValue<string> csv = new(@$"string.Concat(""alpha "", b, ""beta "", 1)");
+        WriteLine writeLine = new();
+        writeLine.Text = new InArgument<string>(csv);
+        Sequence workflow = new();
+        workflow.Activities.Add(writeLine);
+
+        ValidationResults validationResults = DesignValidationServices.Validate(workflow);
+        validationResults.Errors.Count.ShouldBe(1, string.Join("\n", validationResults.Errors.Select(e => e.Message)));
+        validationResults.Errors[0].Message.ShouldContain("The name 'b' does not exist in the current context");
+    }
+
+    [Fact]
+    public void Vb_LambdaExtension()
+    {
+        VisualBasicValue<string> vbv = new("list.First()");
+        WriteLine writeLine = new();
+        writeLine.Text = new InArgument<string>(vbv);
+        Sequence workflow = new();
+        workflow.Activities.Add(writeLine);
+        workflow.Variables.Add(new Variable<List<string>>("list"));
+
+        ValidationResults validationResults = DesignValidationServices.Validate(workflow);
+        validationResults.Errors.Count.ShouldBe(0, string.Join("\n", validationResults.Errors.Select(e => e.Message)));
+    }
+
+    [Fact]
+    public void Vb_Dictionary()
+    {
+        VisualBasicValue<string> vbv = new("something.FooDictionary(\"key\").ToString()");
+        WriteLine writeLine = new();
+        writeLine.Text = new InArgument<string>(vbv);
+        Sequence workflow = new();
+        workflow.Activities.Add(writeLine);
+        workflow.Variables.Add(new Variable<ClassWithCollectionProperties>("something"));
+
+        ValidationResults validationResults = DesignValidationServices.Validate(workflow);
+        validationResults.Errors.Count.ShouldBe(0, string.Join("\n", validationResults.Errors.Select(e => e.Message)));
+    }
+    #region Check locations are not readonly
+    [Fact]
+    public void VB_Readonly_ThrowsError()
+    {
+        var activity = new Assign();
+        activity.To = new OutArgument<bool>(new VisualBasicReference<bool>("Environment.HasShutdownStarted"));
+        activity.Value = new InArgument<bool>(new Literal<bool>(true));
+        var result = DesignValidationServices.Validate(activity);
+        result.Errors.Count.ShouldBe(1);
+        result.Errors.First().Message.ShouldBe("BC30526: Property 'HasShutdownStarted' is 'ReadOnly'.");
+    }
+
+    [Fact]
+    public void VB_NonReadonly_Works()
+    {
+        var activity = new Assign();
+        activity.To = new OutArgument<string>(new VisualBasicReference<string>("Environment.CurrentDirectory"));
+        activity.Value = new InArgument<string>(new Literal<string>("bla"));
+        var result = DesignValidationServices.Validate(activity);
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void VB_Variable_Works()
+    {
+        var seq = new Sequence();
+        seq.Variables.Add(new Variable<string>("v1"));
+        var activity = new Assign();
+        activity.To = new OutArgument<string>(new VisualBasicReference<string>("v1"));
+        activity.Value = new InArgument<string>(new Literal<string>("bla"));
+        seq.Activities.Add(activity);
+        var result = DesignValidationServices.Validate(seq);
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void VB_AssignmentInLocation_DoesNotWork()
+    {
+        var activity = new Assign();
+        activity.To = new OutArgument<string>(new VisualBasicReference<string>("Environment.CurrentDirectory = \"abc\""));
+        activity.Value = new InArgument<string>(new Literal<string>("bla"));
+        var result = DesignValidationServices.Validate(activity);
+        result.Errors.Count.ShouldBe(1);
+        result.Errors.First().Message.ShouldBe("BC30512: Option Strict On disallows implicit conversions from 'Boolean' to 'String'.");
+    }
+
+    [Fact]
+    public void CS_Readonly_ThrowsError()
+    {
+        var activity = new Assign();
+        activity.To = new OutArgument<bool>(new CSharpReference<bool>("Environment.HasShutdownStarted"));
+        activity.Value = new InArgument<bool>(new Literal<bool>(true));
+        var result = DesignValidationServices.Validate(activity);
+        result.Errors.Count.ShouldBe(1);
+        result.Errors.First().Message.ShouldBe("CS0200: Property or indexer 'Environment.HasShutdownStarted' cannot be assigned to -- it is read only");
+    }
+
+    [Fact]
+    public void CS_NonReadonly_Works()
+    {
+        var activity = new Assign();
+        activity.To = new OutArgument<string>(new CSharpReference<string>("Environment.CurrentDirectory"));
+        activity.Value = new InArgument<string>(new Literal<string>("bla"));
+        var result = DesignValidationServices.Validate(activity);
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CS_Variable_Works()
+    {
+        var seq = new Sequence();
+        seq.Variables.Add(new Variable<string>("v1"));
+        var activity = new Assign();
+        activity.To = new OutArgument<string>(new CSharpReference<string>("v1"));
+        activity.Value = new InArgument<string>(new Literal<string>("bla"));
+        seq.Activities.Add(activity);
+        var result = DesignValidationServices.Validate(seq);
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CS_AssignmentInLocation_DoesNotWork()
+    {
+        var activity = new Assign();
+        activity.To = new OutArgument<string>(new CSharpReference<string>("Environment.CurrentDirectory = \"abc\""));
+        activity.Value = new InArgument<string>(new Literal<string>("bla"));
+        var result = DesignValidationServices.Validate(activity);
+        result.Errors.Count.ShouldBe(1);
+        result.Errors.First().Message.ShouldBe("CS0131: The left-hand side of an assignment must be a variable, property or indexer");
+    }
+    #endregion
+
+    [Fact]
+    public void Vb_IntOverflow()
+    {
+        VisualBasicValue<int> vbv = new("2147483648");
+        Sequence workflow = new();
+        workflow.Variables.Add(new Variable<int>("someint"));
+        Assign assign = new() { To = new OutArgument<int>(workflow.Variables[0]), Value = new InArgument<int>(vbv) };
+        workflow.Activities.Add(assign);
+
+        ValidationResults validationResults = DesignValidationServices.Validate(workflow);
+        validationResults.Errors.Count.ShouldBe(1, string.Join("\n", validationResults.Errors.Select(e => e.Message)));
+        validationResults.Errors[0].Message.ShouldContain("Constant expression not representable in type 'Integer'");
+    }
+
+    [Fact]
+    public void VBValidator_StrictOn()
+    {
+        var activity = new WriteLine { Text = new InArgument<string>(new VisualBasicValue<string>("(\"3\" + 3).ToString")) };
+        var result = DesignValidationServices.Validate(activity);
+
+        result.Errors.Count.ShouldBe(1);
+        result.Errors.First().Message.ShouldContain("Option Strict On");
+    }
+
+    [Fact]
+    public void VBValue_ShowsValidationError()
+    {
+        var activity = new WriteLine { Text = new InArgument<string>(new VisualBasicValue<string>("var1")) };
+        var result = DesignValidationServices.Validate(activity);
+
+        result.Errors.Count.ShouldBe(1);
+        result.Errors.First().Message.ShouldContain("'var1' is not declared");
+    }
+
+    [Fact]
+    public void VBReference_ShowsValidationError()
+    {
+        var activity = new Assign
+        {
+            To = new OutArgument<string>(new VisualBasicReference<string>("var1")),
+            Value = new InArgument<string>("\"abc\"")
+        };
+        var result = DesignValidationServices.Validate(activity);
+
+        result.Errors.Count.ShouldBe(1);
+        result.Errors.First().Message.ShouldContain("'var1' is not declared");
+    }
+
+    [Fact]
+    public void VbValue_IdentifiersComparerOrdinalIgnoreCase()
+    {
+        var root = new Sequence();
+        root.Variables.Add(new Variable<List<object>>("count"));
+        root.Activities.Add(new WriteLine { Text = new InArgument<string>(new VisualBasicValue<string>("count.Count.ToString")) });
+
+        var result = DesignValidationServices.Validate(root);
+
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CSValue_ShowsValidationError()
+    {
+        var activity = new WriteLine { Text = new InArgument<string>(new CSharpValue<string>("var1")) };
+        var result = DesignValidationServices.Validate(activity);
+
+        result.Errors.Count.ShouldBe(1);
+        result.Errors.First().Message.ShouldContain("The name 'var1' does not exist in the current context");
+    }
+
+    [Fact]
+    public void CSReference_ShowsValidationError()
+    {
+        var activity = new Assign
+        {
+            To = new OutArgument<string>(new CSharpReference<string>("var1")),
+            Value = new InArgument<string>("\"abc\"")
+        };
+        var result = DesignValidationServices.Validate(activity);
+
+        result.Errors.Count.ShouldBe(1);
+        result.Errors.First().Message.ShouldContain("The name 'var1' does not exist in the current context");
+    }
+
+    [Fact]
+    public void VBValue_Validate_AddsRequiredAssembliesPerExpressionValidated()
+    {
+        var simpleActivity = new WriteLine() { Text = new InArgument<string>(new VisualBasicValue<string>("1.ToString")) };
+
+        var requiresNewtonsoftActivity = new WriteLine { Text = new InArgument<string>(new VisualBasicValue<string>("GetType(JsonConvert).ToString")) };
+        var dy = new DynamicActivity() { Implementation = () => requiresNewtonsoftActivity };
+        TextExpression.SetReferencesForImplementation(dy, new[] { new AssemblyReference("Newtonsoft.Json") });
+        TextExpression.SetNamespacesForImplementation(dy, new[] { "Newtonsoft.Json" });
+
+        // first validate an activity without needing Newtonsoft.Json assembly
+        DesignValidationServices.Validate(simpleActivity);
+
+        // then validate with a new assembly required (Newtonsoft.Json)
+        var result = DesignValidationServices.Validate(dy);
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CSValue_Validate_AddsRequiredAssembliesPerExpressionValidated()
+    {
+
+        var simpleActivity = new WriteLine() { Text = new InArgument<string>(new CSharpValue<string>("1.ToString()")) };
+
+        var requiresNewtonsoftActivity = new WriteLine { Text = new InArgument<string>(new CSharpValue<string>("typeof(JsonConvert).Name")) };
+        var dy = new DynamicActivity() { Implementation = () => requiresNewtonsoftActivity };
+        TextExpression.SetReferencesForImplementation(dy, new[] { new AssemblyReference("Newtonsoft.Json") });
+        TextExpression.SetNamespacesForImplementation(dy, new[] { "Newtonsoft.Json" });
+
+        // first validate an activity without needing Newtonsoft.Json assembly
+        DesignValidationServices.Validate(simpleActivity);
+
+        // then validate with a new assembly required (Newtonsoft.Json)
+        var result = DesignValidationServices.Validate(dy);
+        result.Errors.ShouldBeEmpty();
+    }
+
+
+    [Fact]
+    public void VBRoslynValidator_ValidatesMoreThan16Arguments()
+    {
+        var sequence = new Sequence();
+        for (int i = 0; i < 20; i++)
+        {
+            sequence.Variables.Add(new Variable<string>($"var{i}"));
+        }
+        var testActivity = new VisualBasicValue<string[]>(string.Format("{{{0}}}", string.Join(", ", Enumerable.Range(0, 20).Select(r => $"var{r}"))));
+        sequence.Activities.Add(testActivity);
+        var result = DesignValidationServices.Validate(sequence);
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CSRoslynValidator_ValidatesMoreThan16Arguments()
+    {
+        var sequence = new Sequence();
+        for (int i = 0; i < 20; i++)
+        {
+            sequence.Variables.Add(new Variable<string>($"var{i}"));
+        }
+        var testActivity = new CSharpValue<string[]>(string.Format("new [] {{{0}}}", string.Join(", ", Enumerable.Range(0, 20).Select(r => $"var{r}"))));
+        sequence.Activities.Add(testActivity);
+        var result = DesignValidationServices.Validate(sequence);
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void VB_Multithreaded_NoError()
+    {
+        var activities = new List<Activity>();
+        var tasks = new List<Task>();
+        var results = new List<ValidationResults>();
+        for (var i = 0; i < 20; i++)
+        {
+            var seq = new Sequence();
+            seq.Variables.Add(new Variable<int>("sum"));
+            for (var j = 0; j < 10000; j++)
+            {
+                seq.Activities.Add(new Assign
+                {
+                    To = new OutArgument<int>(new VisualBasicReference<int>("sum")),
+                    Value = new InArgument<int>(new VisualBasicValue<int>($"sum + {j}"))
+                });
+            }
+        }
+        foreach (var activity in activities)
+        {
+            tasks.Add(Task.Run(() =>
+            {
+                results.Add(DesignValidationServices.Validate(activity));
+            }));
+        }
+        Task.WaitAll(tasks.ToArray());
+
+        results.All(r => !r.Errors.Any() && !r.Warnings.Any()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CS_Multithreaded_NoError()
+    {
+        var activities = new List<Activity>();
+        var tasks = new List<Task>();
+        var results = new List<ValidationResults>();
+        for (var i = 0; i < 20; i++)
+        {
+            var seq = new Sequence();
+            seq.Variables.Add(new Variable<int>("sum"));
+            for (var j = 0; j < 10000; j++)
+            {
+                seq.Activities.Add(new Assign
+                {
+                    To = new OutArgument<int>(new CSharpReference<int>("sum")),
+                    Value = new InArgument<int>(new CSharpValue<int>($"sum + {j}"))
+                });
+            }
+        }
+        foreach (var activity in activities)
+        {
+            tasks.Add(Task.Run(() =>
+            {
+                results.Add(DesignValidationServices.Validate(activity));
+            }));
+        }
+        Task.WaitAll(tasks.ToArray());
+
+        results.All(r => !r.Errors.Any() && !r.Warnings.Any()).ShouldBeTrue();
+    }
+}

--- a/src/UiPath.Workflow.Runtime/ActivityLocationReferenceEnvironment.cs
+++ b/src/UiPath.Workflow.Runtime/ActivityLocationReferenceEnvironment.cs
@@ -12,7 +12,10 @@ internal sealed class ActivityLocationReferenceEnvironment : LocationReferenceEn
     private Dictionary<string, LocationReference> _declarations;
     private List<LocationReference> _unnamedDeclarations;
 
-    public ActivityLocationReferenceEnvironment() { }
+    public ActivityLocationReferenceEnvironment()
+    {
+        ValidationScope = new();
+    }
 
     public ActivityLocationReferenceEnvironment(LocationReferenceEnvironment parent)
     {
@@ -21,6 +24,8 @@ internal sealed class ActivityLocationReferenceEnvironment : LocationReferenceEn
         {
             CompileExpressions = parent.CompileExpressions;
             IsValidating = parent.IsValidating;
+            IsDesignValidating = parent.IsDesignValidating;
+            ValidationScope = parent.ValidationScope;
             InternalRoot = parent.Root;
         }
     }

--- a/src/UiPath.Workflow.Runtime/LocationReferenceEnvironment.cs
+++ b/src/UiPath.Workflow.Runtime/LocationReferenceEnvironment.cs
@@ -3,6 +3,7 @@
 
 namespace System.Activities;
 using Runtime;
+using System.Activities.Validation;
 
 [Fx.Tag.XamlVisible(false)]
 public abstract class LocationReferenceEnvironment
@@ -15,6 +16,13 @@ public abstract class LocationReferenceEnvironment
     /// Indicates if this LRE is created as part of activity validation.
     /// </summary>
     internal bool IsValidating { get; set; }
+
+    /// <summary>
+    /// Indicates if this LRE is created as part of activity validation.
+    /// </summary>
+    internal bool IsDesignValidating { get; set; }
+
+    internal ValidationScope ValidationScope { get; set; }
 
     public abstract Activity Root { get; }
 

--- a/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
@@ -430,6 +430,7 @@ public static class ActivityValidationServices
             _rootToValidate = toValidate;
             _environment = settings.Environment ?? new ActivityLocationReferenceEnvironment();
             _environment.IsValidating = !settings.ForceExpressionCache;
+            _environment.IsDesignValidating = settings.IsDesignValidating;
             if (settings.SkipExpressionCompilation)
             {
                 _environment.CompileExpressions = true;

--- a/src/UiPath.Workflow.Runtime/Validation/ExpressionToValidate.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ExpressionToValidate.cs
@@ -1,0 +1,15 @@
+﻿
+namespace System.Activities.Validation;
+
+internal sealed class ExpressionToValidate
+{
+    public Activity Activity { get; init; }
+
+    public string ExpressionText { get; init; }
+
+    public LocationReferenceEnvironment Environment { get; init; }
+
+    public Type ResultType { get; init; }
+
+    public bool IsLocation { get; init; }
+}

--- a/src/UiPath.Workflow.Runtime/Validation/ValidationScope.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ValidationScope.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Immutable;
+
+namespace System.Activities.Validation
+{
+    public class ValidationScope
+    {
+        private readonly Dictionary<string, ExpressionToValidate> _expressionsToValidate = new();
+        private string _language;
+        internal void AddExpression<T>(CodeActivity<T> activity, string expressionText, LocationReferenceEnvironment environment, string language, bool isLocation)
+        {
+            _language ??= language;
+            if (_language != language)
+            {
+                activity.AddTempValidationError(new ValidationError("Expression language mismatch", activity));
+                return;
+            }
+            _expressionsToValidate.Add(activity.Id,
+                new ExpressionToValidate
+                {
+                    Activity = activity,
+                    ExpressionText = expressionText,
+                    IsLocation = isLocation,
+                    ResultType = typeof(T),
+                    Environment = environment
+                });
+        }
+
+        internal string Language => _language;
+
+        internal ExpressionToValidate GetExpression(string activityId) => _expressionsToValidate[activityId];
+
+        internal ImmutableArray<ExpressionToValidate> GetAllExpressions() => _expressionsToValidate.Values.ToImmutableArray();
+
+        internal void Reset() => _expressionsToValidate.Clear();
+    }
+}

--- a/src/UiPath.Workflow.Runtime/Validation/ValidationSettings.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ValidationSettings.cs
@@ -81,4 +81,6 @@ public class ValidationSettings
     /// Defaulting to true until validation path is proven.
     /// </remarks>
     public bool ForceExpressionCache { get; set; } = true;
+
+    internal bool IsDesignValidating { get; set; }
 }

--- a/src/UiPath.Workflow/Activities/Utils/CSharpCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CSharpCompilerHelper.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.CSharp;
-using System;
 using System.Text;
 using System.Threading;
 
@@ -7,7 +6,7 @@ namespace System.Activities
 {
     public sealed class CSharpCompilerHelper : CompilerHelper
     {
-        static int crt = 0;
+        private static int crt = 0;
 
         public override int IdentifierKind => (int)SyntaxKind.IdentifierName;
 
@@ -19,12 +18,11 @@ namespace System.Activities
             if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
                 return $"public static Expression<Func<{types}>> CreateExpression() => ({names}) => {code};";
 
-
             var (myDelegate, name) = DefineDelegate(types);
             return $"{myDelegate} \n public static Expression<{name}<{types}>> CreateExpression() => ({names}) => {code};";
         }
 
-        private static (string, string) DefineDelegate(string types)
+        public override (string, string) DefineDelegate(string types)
         {
             var crtValue = Interlocked.Add(ref crt, 1);
             var arrayType = types.Split(",");

--- a/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
@@ -9,5 +9,7 @@ namespace System.Activities
         public abstract StringComparer IdentifierNameComparer { get; }
 
         public abstract int IdentifierKind { get; }
+
+        public abstract (string, string) DefineDelegate(string types);
     }
 }

--- a/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.VisualBasic;
-using System;
 using System.Text;
 using System.Threading;
 
@@ -7,7 +6,7 @@ namespace System.Activities
 {
     public sealed class VBCompilerHelper : CompilerHelper
     {
-        static int crt = 0;
+        private static int crt = 0;
 
         public override int IdentifierKind => (int)SyntaxKind.IdentifierName;
 
@@ -23,7 +22,7 @@ namespace System.Activities
             return $"{myDelegate} \n Public Shared Function CreateExpression() As Expression(Of {name}(Of {types}))\nReturn Function({names}) ({code})\nEnd Function";
         }
 
-        private static (string, string) DefineDelegate(string types)
+        public override (string, string) DefineDelegate(string types)
         {
             var crtValue = Interlocked.Add(ref crt, 1);
 

--- a/src/UiPath.Workflow/Microsoft/TextExpressionBase.cs
+++ b/src/UiPath.Workflow/Microsoft/TextExpressionBase.cs
@@ -1,0 +1,24 @@
+﻿using System.Activities.Expressions;
+using System.Linq.Expressions;
+
+namespace System.Activities
+{
+    public abstract class TextExpressionBase<TResult> : CodeActivity<TResult>, ITextExpression
+    {
+        public abstract string ExpressionText { get; set; }
+
+        public abstract string Language { get; }
+
+        public abstract Expression GetExpressionTree();
+
+        protected bool QueueForValidation<T>(CodeActivityMetadata metadata, bool isLocation)
+        {
+            if (metadata.Environment.IsDesignValidating)
+            {
+                metadata.Environment.ValidationScope.AddExpression(this, ExpressionText, metadata.Environment, Language, isLocation);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicValue.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicValue.cs
@@ -17,8 +17,8 @@ using ActivityContext = System.Activities.ActivityContext;
 namespace Microsoft.VisualBasic.Activities;
 
 [DebuggerStepThrough]
-public sealed class VisualBasicValue<TResult> : CodeActivity<TResult>, IValueSerializableExpression,
-    IExpressionContainer, ITextExpression
+public sealed class VisualBasicValue<TResult> : TextExpressionBase<TResult>, IValueSerializableExpression,
+    IExpressionContainer
 {
     private Func<ActivityContext, TResult> _compiledExpression;
     private Expression<Func<ActivityContext, TResult>> _expressionTree;
@@ -28,12 +28,12 @@ public sealed class VisualBasicValue<TResult> : CodeActivity<TResult>, IValueSer
 
     public VisualBasicValue(string expressionText) : this() => ExpressionText = expressionText;
 
-    public string ExpressionText { get; set; }
+    public override string ExpressionText { get; set; }
 
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public string Language => VisualBasicHelper.Language;
+    public override string Language => VisualBasicHelper.Language;
 
-    public Expression GetExpressionTree()
+    public override Expression GetExpressionTree()
     {
         if (!IsMetadataCached)
         {
@@ -75,7 +75,7 @@ public sealed class VisualBasicValue<TResult> : CodeActivity<TResult>, IValueSer
     {
         if (_expressionTree == null)
         {
-            return (TResult) _invoker.InvokeExpression(context);
+            return (TResult)_invoker.InvokeExpression(context);
         }
         _compiledExpression ??= _expressionTree.Compile();
         return _compiledExpression(context);
@@ -85,7 +85,18 @@ public sealed class VisualBasicValue<TResult> : CodeActivity<TResult>, IValueSer
     {
         _expressionTree = null;
         _invoker = new CompiledExpressionInvoker(this, false, metadata);
+
+        if (metadata.Environment.CompileExpressions)
+        {
+            return;
+        }
+
         if (VbExpressionValidator.Instance.TryValidate<TResult>(this, metadata, ExpressionText))
+        {
+            return;
+        }
+
+        if (QueueForValidation<TResult>(metadata, false))
         {
             return;
         }

--- a/src/UiPath.Workflow/Validation/DesignCSharpExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/DesignCSharpExpressionValidator.cs
@@ -1,0 +1,145 @@
+﻿// This file is part of Core WF which is licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.CSharp.Activities;
+using ReflectionMagic;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace System.Activities.Validation;
+
+/// <summary>
+///     Validates C# expressions for use in fast design-time expression validation.
+/// </summary>
+public class DesignCSharpExpressionValidator : DesignRoslynExpressionValidator
+{
+    private static readonly Lazy<DesignCSharpExpressionValidator> s_default = new();
+    private static DesignCSharpExpressionValidator s_instance;
+    private const string _valueValidationTemplate = "public static Expression<Func<{0}>> CreateExpression{1}() => ({2}) => {3};//activityId:{4}";
+    private const string _delegateValueValidationTemplate = "{0}\npublic static Expression<{1}<{2}>> CreateExpression{3}() => ({4}) => {5};//activityId:{6}";
+    private const string _referenceValidationTemplate = "public static {0} IsLocation{1}() => ({2}) => {3} = default;//activityId:{4}";
+
+    private static readonly CompilerHelper s_compilerHelper = new CSharpCompilerHelper();
+    private static readonly CSharpParseOptions s_csScriptParseOptions = new(kind: SourceCodeKind.Script);
+
+    private static readonly dynamic s_typeOptions = GetTypeOptions();
+    private static readonly dynamic s_typeNameFormatter = GetTypeNameFormatter();
+
+    private static readonly HashSet<Assembly> s_defaultReferencedAssemblies = new()
+    {
+        typeof(Collections.ICollection).Assembly,
+        typeof(ICollection<>).Assembly,
+        typeof(Enum).Assembly,
+        typeof(ComponentModel.BrowsableAttribute).Assembly,
+        typeof(CSharpValue<>).Assembly,
+        Assembly.Load("netstandard"),
+        Assembly.Load("System.Runtime")
+    };
+
+    private readonly Compilation DefaultCompilationUnit = InitDefaultCompilationUnit();
+
+    /// <summary>
+    ///     Singleton instance of the default validator.
+    /// </summary>
+    public static DesignCSharpExpressionValidator Instance
+    {
+        get => s_instance ?? s_default.Value;
+        set => s_instance = value;
+    }
+
+    protected override CompilerHelper CompilerHelper { get; } = new CSharpCompilerHelper();
+
+    protected override string ActivityIdentifierRegex { get; } = @"(\/\/activityId):(.*)";
+
+    /// <summary>
+    ///     Initializes the MetadataReference collection.
+    /// </summary>
+    public DesignCSharpExpressionValidator() : this(null) { }
+
+    /// <summary>
+    ///     Initializes the MetadataReference collection.
+    /// </summary>
+    /// <param name="referencedAssemblies">
+    ///     Assemblies to seed the collection.
+    /// </param>
+    public DesignCSharpExpressionValidator(HashSet<Assembly> referencedAssemblies)
+        : base(referencedAssemblies != null
+               ? new HashSet<Assembly>(s_defaultReferencedAssemblies.Union(referencedAssemblies))
+               : s_defaultReferencedAssemblies)
+    { }
+
+    protected override Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces)
+    {
+        var metadataReferences = GetMetadataReferencesForExpression(assemblies);
+
+        var options = DefaultCompilationUnit.Options as CSharpCompilationOptions;
+        return DefaultCompilationUnit.WithOptions(options.WithUsings(namespaces)).WithReferences(metadataReferences);
+    }
+
+    private static Compilation InitDefaultCompilationUnit()
+    {
+        var assemblyName = Guid.NewGuid().ToString();
+        CSharpCompilationOptions options = new(
+            OutputKind.DynamicallyLinkedLibrary,
+            mainTypeName: null,
+            usings: null,
+            optimizationLevel: OptimizationLevel.Debug,
+            checkOverflow: false,
+            xmlReferenceResolver: null,
+            sourceReferenceResolver: SourceFileResolver.Default,
+            concurrentBuild: !RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")),
+            assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default);
+        return CSharpCompilation.Create(assemblyName, null, null, options);
+    }
+
+    protected override string CreateValueCode(string types, string names, string code, string activityId, int index)
+    {
+        var arrayType = types.Split(",");
+        if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
+            return string.Format(_valueValidationTemplate, types, index, names, code, activityId);
+
+        var (myDelegate, name) = s_compilerHelper.DefineDelegate(types);
+        return string.Format(_delegateValueValidationTemplate, myDelegate, name, types, index, names, code, activityId);
+    }
+
+    protected override string CreateReferenceCode(string types, string names, string code, string activityId, int index)
+    {
+        var actionDefinition = types.Any() ? $"Action<{string.Join(Comma, types)}>" : "Action";
+        return string.Format(_referenceValidationTemplate, actionDefinition, index, names, code, activityId);
+    }
+
+    protected override SyntaxTree GetSyntaxTreeForExpression(string expressionText) =>
+        CSharpSyntaxTree.ParseText(expressionText, s_csScriptParseOptions);
+
+    protected override SyntaxTree GetSyntaxTreeForValidation(string expressionText) =>
+        GetSyntaxTreeForExpression(expressionText);
+
+    protected override string GetTypeName(Type type) =>
+        (string)s_typeNameFormatter.FormatTypeName(type, s_typeOptions);
+
+    private static object GetTypeOptions()
+    {
+        var formatterOptionsType =
+            typeof(ObjectFormatter).Assembly.GetType(
+                "Microsoft.CodeAnalysis.Scripting.Hosting.CommonTypeNameFormatterOptions");
+        const int arrayBoundRadix = 0;
+        const bool showNamespaces = true;
+        return Activator.CreateInstance(formatterOptionsType, arrayBoundRadix, showNamespaces);
+    }
+
+    private static object GetTypeNameFormatter()
+    {
+        return typeof(CSharpScript)
+            .Assembly
+            .GetType("Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.CSharpObjectFormatter")
+            .AsDynamicType()
+            .s_impl
+            .TypeNameFormatter;
+    }
+}

--- a/src/UiPath.Workflow/Validation/DesignVBExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/DesignVBExpressionValidator.cs
@@ -1,0 +1,127 @@
+﻿// This file is part of Core WF which is licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting;
+using Microsoft.VisualBasic.Activities;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace System.Activities.Validation;
+/// <summary>
+///     Validates VB.NET expressions for use in fast design-time expression validation.
+/// </summary>
+public class DesignVBExpressionValidator : DesignRoslynExpressionValidator
+{
+    private static readonly Lazy<DesignVBExpressionValidator> s_default = new();
+    private static DesignVBExpressionValidator s_instance;
+    private static readonly CompilerHelper s_compilerHelper = new VBCompilerHelper();
+
+    private const string _valueValidationTemplate = "Public Shared Function CreateExpression{0}() As Expression(Of Func(Of {1}))'activityId:{4}\nReturn Function({2}) ({3})'activityId:{4}\nEnd Function";
+    private const string _delegateValueValidationTemplate = "{0}\nPublic Shared Function CreateExpression{1}() As Expression(Of {2}(Of {3}))'activityId:{6}\nReturn Function({4}) ({5})'activityId:{6}\nEnd Function";
+    private const string _referenceValidationTemplate = "Public Shared Function IsLocation{0}() As {1}'activityId:{4}\nReturn Function({2}) as Action'activityId:{3}\nReturn Sub() {3} = Nothing'activityId:{4}\nEnd Function'activityId:{4}\nEnd Function";
+
+    private static readonly VisualBasicParseOptions s_vbScriptParseOptions =
+        new(kind: SourceCodeKind.Script, languageVersion: LanguageVersion.Latest);
+
+    private static readonly HashSet<Assembly> s_defaultReferencedAssemblies = new()
+    {
+        typeof(Collections.ICollection).Assembly,
+        typeof(Enum).Assembly,
+        typeof(ComponentModel.BrowsableAttribute).Assembly,
+        typeof(VisualBasicValue<>).Assembly,
+        Assembly.Load("netstandard"),
+        Assembly.Load("System.Runtime")
+    };
+
+    private readonly Compilation DefaultCompilationUnit = InitDefaultCompilationUnit();
+
+    /// <summary>
+    ///     Singleton instance of the default validator.
+    /// </summary>
+    public static DesignVBExpressionValidator Instance
+    {
+        get => s_instance ?? s_default.Value;
+        set => s_instance = value;
+    }
+
+    protected override CompilerHelper CompilerHelper { get; } = new VBCompilerHelper();
+
+    protected override string ActivityIdentifierRegex { get; } = "('activityId):(.*)";
+
+    /// <summary>
+    ///     Initializes the MetadataReference collection.
+    /// </summary>
+    public DesignVBExpressionValidator() : this(null) { }
+
+    /// <summary>
+    ///     Initializes the MetadataReference collection.
+    /// </summary>
+    /// <param name="referencedAssemblies">
+    ///     Assemblies to seed the collection.
+    /// </param>
+    public DesignVBExpressionValidator(HashSet<Assembly> referencedAssemblies)
+        : base(referencedAssemblies != null
+               ? new HashSet<Assembly>(s_defaultReferencedAssemblies.Union(referencedAssemblies))
+               : s_defaultReferencedAssemblies)
+    { }
+
+    protected override Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces)
+    {
+        var globalImports = GlobalImport.Parse(namespaces);
+        var metadataReferences = GetMetadataReferencesForExpression(assemblies);
+
+        var options = DefaultCompilationUnit.Options as VisualBasicCompilationOptions;
+        return DefaultCompilationUnit.WithOptions(options!.WithGlobalImports(globalImports)).WithReferences(metadataReferences);
+    }
+
+    protected override SyntaxTree GetSyntaxTreeForExpression(string expressionText) =>
+        VisualBasicSyntaxTree.ParseText("? " + expressionText, s_vbScriptParseOptions);
+
+    protected override SyntaxTree GetSyntaxTreeForValidation(string expressionText) =>
+        VisualBasicSyntaxTree.ParseText(expressionText, s_vbScriptParseOptions);
+
+    protected override string GetTypeName(Type type) => VisualBasicObjectFormatter.FormatTypeName(type);
+
+    private static Compilation InitDefaultCompilationUnit()
+    {
+        var assemblyName = Guid.NewGuid().ToString();
+        VisualBasicCompilationOptions options = new(
+            OutputKind.DynamicallyLinkedLibrary,
+            mainTypeName: null,
+            globalImports: null,
+            rootNamespace: "",
+            optionStrict: OptionStrict.On,
+            optionInfer: true,
+            optionExplicit: true,
+            optionCompareText: false,
+            embedVbCoreRuntime: false,
+            optimizationLevel: OptimizationLevel.Debug,
+            checkOverflow: true,
+            xmlReferenceResolver: null,
+            sourceReferenceResolver: SourceFileResolver.Default,
+            concurrentBuild: !RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")));
+        return VisualBasicCompilation.Create(assemblyName, null, null, options);
+    }
+
+    protected override string CreateValueCode(string types, string names, string code, string activityId, int index)
+    {
+        var arrayType = types.Split(",");
+        if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
+            return string.Format(_valueValidationTemplate, index, types, names, code, activityId);
+
+        var (myDelegate, name) = s_compilerHelper.DefineDelegate(types);
+        return string.Format(_delegateValueValidationTemplate, myDelegate, index, name, types, names, code, activityId);
+    }
+
+    protected override string CreateReferenceCode(string types, string names, string code, string activityId, int index)
+    {
+        var actionDefinition = types.Any() ? $"Action(Of {string.Join(Comma, types)})" : "Action";
+        return string.Format(_referenceValidationTemplate, index, actionDefinition, names, code, activityId);
+    }
+
+
+}

--- a/src/UiPath.Workflow/Validation/DesignValidationServices.cs
+++ b/src/UiPath.Workflow/Validation/DesignValidationServices.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace System.Activities.Validation;
+
+public static class DesignValidationServices
+{
+    public static ValidationResults Validate(Activity activity) => Validate(activity, new());
+
+    public static ValidationResults Validate(Activity activity, ValidationSettings settings)
+    {
+        settings.Environment ??= new ActivityLocationReferenceEnvironment();
+        settings.Environment.ValidationScope.Reset();
+        settings.IsDesignValidating = true;
+        // make sure we don't double validate
+        settings.ForceExpressionCache = true;
+        var results = ActivityValidationServices.Validate(activity, settings);
+        var expressionResults = GetValidator(settings.Environment).Validate(activity, settings.Environment.ValidationScope);
+        if (expressionResults.Any())
+        {
+            var errors = new List<ValidationError>();
+            errors.AddRange(results.Errors);
+            errors.AddRange(results.Warnings);
+            errors.AddRange(expressionResults);
+            results = new(errors);
+        }
+        return results;
+    }
+
+    public static Activity Resolve(Activity root, string id) => WorkflowInspectionServices.Resolve(root, id);
+
+    private static DesignRoslynExpressionValidator GetValidator(LocationReferenceEnvironment environment)
+    {
+        return environment.ValidationScope.Language == "C#"
+            ? DesignCSharpExpressionValidator.Instance
+            : DesignVBExpressionValidator.Instance;
+    }
+}


### PR DESCRIPTION
STILL A DRAFT
Not a fan of having 2 validation services, but the benefits of this are that we isolate the new implementation better, till battle-proven.
Summary:
- compile all expressions at once
- get diagnostics only once
- make sure existing functionality is not affected
- moved condition environment.CompileExpressions to its proper location in each ITextExpression implementation