### PR TITLE
Avoid unnecessary location argument for VB compiling

### DIFF
--- a/src/UiPath.Workflow.Runtime/Expressions/CompiledExpressionInvoker.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/CompiledExpressionInvoker.cs
@@ -209,11 +209,16 @@ public class CompiledExpressionInvoker
             current = current.Parent;
         }
 
+        bool requiresCompilation = _textExpression.Language != "VB";
+
         foreach (LocationReferenceEnvironment environment in environments)
         {
             foreach (LocationReference reference in environment.GetLocationReferences())
             {
-                _accessor.CreateLocationArgument(reference, false);
+                if (requiresCompilation)
+                {
+                    _accessor.CreateLocationArgument(reference, false);
+                }
                 _locationReferences.Add(new InlinedLocationReference(reference, _metadata.CurrentActivity));
             }
         }
@@ -238,7 +243,7 @@ public class CompiledExpressionInvoker
             // for locations that are referenced in the expressions. To maintain 
             // consistency the we call the CreateRequiredArguments method seperately to
             // generates auto arguments only for locations that are referenced.
-            if (_textExpression.Language == "VB")
+            if (!requiresCompilation)
             {
                 IList<string> requiredLocationNames = _compiledRoot.GetRequiredLocations(_expressionId);
                 CreateRequiredArguments(requiredLocationNames);


### PR DESCRIPTION
For `CompiledExpressionInvoker.ProcessLocationReferences()`, the microsoft reference source is not always creating location argument, but only when `RequiresCompilation` is true, which is for C#.

https://github.com/microsoft/referencesource/blob/master/System.Activities/System/Activities/Expressions/CompiledExpressionInvoker.cs#L245

This helps for performance a lot when there are a lot of expressions to compile.
(21 complex xaml files, the first Execute() drops from 27s to 20s)