### PR TITLE
fix: sw compatibility

### DIFF
--- a/src/UiPath.Workflow/Validation/CSharpExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/CSharpExpressionValidator.cs
@@ -16,8 +16,9 @@ namespace System.Activities.Validation;
 
 /// <summary>
 ///     Validates C# expressions for use in fast design-time expression validation.
+///     ⚠️ Do not seal this class, required for customization by certain hosts.
 /// </summary>
-public sealed class CSharpExpressionValidator : RoslynExpressionValidator
+public class CSharpExpressionValidator : RoslynExpressionValidator
 {
     private static readonly Lazy<CSharpExpressionValidator> s_instance = new(() => new(s_defaultReferencedAssemblies));
     private const string _valueValidationTemplate = "public static Expression<Func<{0}>> CreateExpression{1}() => ({2}) => {3};//activityId:{4}";

--- a/src/UiPath.Workflow/Validation/VBExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/VBExpressionValidator.cs
@@ -13,8 +13,9 @@ using System.Runtime.InteropServices;
 namespace System.Activities.Validation;
 /// <summary>
 ///     Validates VB.NET expressions for use in fast design-time expression validation.
+///     ⚠️ Do not seal this class, required for customization by certain hosts.
 /// </summary>
-public sealed class VbExpressionValidator : RoslynExpressionValidator
+public class VbExpressionValidator : RoslynExpressionValidator
 {
     private static readonly Lazy<VbExpressionValidator> s_instance = new(() => new(s_defaultReferencedAssemblies));
     private static readonly CompilerHelper s_compilerHelper = new VBCompilerHelper();


### PR DESCRIPTION
- unseal ExpressionValidator classes
- allow curation of validation errors produces by compilation
