### PR TITLE
Fix validation errors [STUD-65311] [STUD-65835]

### DIFF
--- a/src/UiPath.Workflow/Validation/CSharpExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/CSharpExpressionValidator.cs
@@ -21,8 +21,8 @@ namespace System.Activities.Validation;
 public class CSharpExpressionValidator : RoslynExpressionValidator
 {
     private static readonly Lazy<CSharpExpressionValidator> s_instance = new(() => new(s_defaultReferencedAssemblies));
-    private const string _valueValidationTemplate = "public static Expression<Func<{0}>> CreateExpression{1}() => ({2}) => {3};//activityId:{4}";
-    private const string _delegateValueValidationTemplate = "{0}\npublic static Expression<{1}<{2}>> CreateExpression{3}() => ({4}) => {5};//activityId:{6}";
+    private const string _valueValidationTemplate = "public static System.Linq.Expressions.Expression<System.Func<{0}>> CreateExpression{1}() => ({2}) => {3};//activityId:{4}";
+    private const string _delegateValueValidationTemplate = "{0}\npublic static System.Linq.Expressions.Expression<{1}<{2}>> CreateExpression{3}() => ({4}) => {5};//activityId:{6}";
     private const string _referenceValidationTemplate = "public static {0} IsLocation{1}() => ({2}) => {3} = default({4});//activityId:{5}";
 
     private static readonly CompilerHelper s_compilerHelper = new CSharpCompilerHelper();

--- a/src/UiPath.Workflow/Validation/VBExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/VBExpressionValidator.cs
@@ -20,9 +20,9 @@ public class VbExpressionValidator : RoslynExpressionValidator
     private static readonly Lazy<VbExpressionValidator> s_instance = new(() => new(s_defaultReferencedAssemblies));
     private static readonly CompilerHelper s_compilerHelper = new VBCompilerHelper();
 
-    private const string _valueValidationTemplate = "Public Shared Function CreateExpression{0}() As Expression(Of Func(Of {1}))'activityId:{4}\nReturn Function({2}) ({3})'activityId:{4}\nEnd Function";
-    private const string _delegateValueValidationTemplate = "{0}\nPublic Shared Function CreateExpression{1}() As Expression(Of {2}(Of {3}))'activityId:{6}\nReturn Function({4}) ({5})'activityId:{6}\nEnd Function";
-    private const string _referenceValidationTemplate = "Public Shared Function IsLocation{0}() As {1}'activityId:{4}\nReturn Function({2}) as Action'activityId:{3}\nReturn Sub() {3} = CType(Nothing, {4})'activityId:{5}\nEnd Function'activityId:{4}\nEnd Function";
+    private const string _valueValidationTemplate = "Public Shared Function CreateExpression{0}() As System.Linq.Expressions.Expression(Of System.Func(Of {1}))'activityId:{4}\nReturn Function({2}) ({3})'activityId:{4}\nEnd Function";
+    private const string _delegateValueValidationTemplate = "{0}\nPublic Shared Function CreateExpression{1}() As System.Linq.Expressions.Expression(Of {2}(Of {3}))'activityId:{6}\nReturn Function({4}) ({5})'activityId:{6}\nEnd Function";
+    private const string _referenceValidationTemplate = "Public Shared Function IsLocation{0}() As {1}'activityId:{5}\nReturn Function({2}) as System.Action'activityId:{5}\nReturn Sub() {3} = CType(Nothing, {4})'activityId:{5}\nEnd Function'activityId:{5}\nEnd Function";
 
     private static readonly VisualBasicParseOptions s_vbScriptParseOptions =
         new(kind: SourceCodeKind.Script, languageVersion: LanguageVersion.Latest);
@@ -113,7 +113,7 @@ public class VbExpressionValidator : RoslynExpressionValidator
     protected override string CreateReferenceCode(string types, string names, string code, string activityId, string returnType, int index)
     {
         var actionDefinition = !string.IsNullOrWhiteSpace(types)
-            ? $"Action(Of {string.Join(Comma, types)})" 
+            ? $"Action(Of {string.Join(Comma, types)})"
             : "Action";
         return string.Format(_referenceValidationTemplate, index, actionDefinition, names, code, returnType, activityId);
     }


### PR DESCRIPTION
ActivityId was set wrong on vbvalidator (wrong argument index in for some lines)
Bonus: fully qualified Func and Action and Expression types, so we dont encouter clashes (like with microsoft excel package clashing with Action type coming from 2 different namespaces)