### PR TITLE
Expose UnaryExpressionHelpers and BinaryExpressionHelpers

### DIFF
--- a/src/UiPath.Workflow.Runtime/Expressions/AddAssign.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/AddAssign.cs
@@ -1,0 +1,98 @@
+﻿// This file is part of Core WF which is licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+using System.Activities.Validation;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Numerics;
+
+namespace System.Activities.Expressions
+{
+    /// <summary>
+    /// A code activity which incrementally assigns a numeral.
+    /// </summary>
+    /// <example>
+    /// int myNum = 5;
+    /// myNum += 5; // 10.
+    /// </example>
+    /// <typeparam name="TLeft">The operand to modify.</typeparam>
+    /// <typeparam name="TRight">The operand with which to modify <typeparamref name="TLeft"/>.</typeparam>
+    /// <typeparam name="TResult">The resulting type of hte operation.</typeparam>
+    public sealed class AddAssign<TLeft, TRight, TResult> : CodeActivity<TResult>
+#if NET7_0_OR_GREATER
+        where TLeft : INumber<TLeft>
+        where TRight : INumber<TRight>
+        where TResult : INumber<TResult>
+#endif
+    {
+        private static Func<TLeft, TRight, TResult>? checkedOperationFunction = null;
+        private static Func<TLeft, TRight, TResult>? uncheckedOperationFunction = null;
+
+        /// <summary>
+        /// Gets or sets the left operand which will be modified by this operation.
+        /// </summary>
+        [RequiredArgument]
+        public InArgument<TLeft> Left { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the right operand which will be the modifier for this operation.
+        /// </summary>
+        [RequiredArgument]
+        public InArgument<TRight> Right { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this operation will happen in a checked or unchecked context.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool IsChecked { get; set; } = true;
+
+        /// <inheritdoc/>
+        protected override void CacheMetadata(CodeActivityMetadata metadata)
+        {
+            BinaryExpressionHelper.OnGetArguments(metadata, Left, Right);
+
+            if (IsChecked)
+            {
+                EnsureOperationFunction(metadata, ref checkedOperationFunction, ExpressionType.AddAssignChecked);
+            }
+            else
+            {
+                EnsureOperationFunction(metadata, ref uncheckedOperationFunction, ExpressionType.AddAssign);
+            }
+        }
+
+        private static void EnsureOperationFunction
+        (
+            CodeActivityMetadata metadata,
+            ref Func<TLeft, TRight, TResult>? operationFunction,
+            ExpressionType operatorType
+        )
+        {
+            if (operationFunction == null)
+            {
+                if (!BinaryExpressionHelper.TryGenerateLinqDelegate(
+                    operatorType,
+                    out operationFunction,
+                    out ValidationError? validationError))
+                {
+                    metadata.AddValidationError(validationError);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override TResult Execute(CodeActivityContext context)
+        {
+            TLeft leftValue = Left.Get(context);
+            TRight rightValue = Right.Get(context);
+
+            // If user changed checked flag between open and execution, an NRE may be thrown.
+            // This is by design.
+            // Nullability check silenced because the corresponding value is guaranteed to be
+            // non-null
+            return IsChecked
+                ? checkedOperationFunction!(leftValue, rightValue)
+                : uncheckedOperationFunction!(leftValue, rightValue);
+        }
+    }
+}

--- a/src/UiPath.Workflow.Runtime/Expressions/BinaryExpressionHelper.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/BinaryExpressionHelper.cs
@@ -8,8 +8,19 @@ using System.Linq.Expressions;
 
 namespace System.Activities.Expressions;
 
-internal static class BinaryExpressionHelper
+/// <summary>
+/// Helpers for binary expressions.
+/// </summary>
+public static class BinaryExpressionHelper
 {
+    /// <summary>
+    /// Binds metadata when getting arguments.
+    /// </summary>
+    /// <typeparam name="TLeft">The type of the left argument.</typeparam>
+    /// <typeparam name="TRight">The type of the right argument.</typeparam>
+    /// <param name="metadata">The metadata.</param>
+    /// <param name="left">The left argument.</param>
+    /// <param name="right">The right argument.</param>
     public static void OnGetArguments<TLeft, TRight>(CodeActivityMetadata metadata, InArgument<TLeft> left, InArgument<TRight> right)
     {
         RuntimeArgument rightArgument = new("Right", typeof(TRight), ArgumentDirection.In, true);
@@ -26,6 +37,16 @@ internal static class BinaryExpressionHelper
             });
     }
 
+    /// <summary>
+    /// Generates a <see cref="System.Linq"/> delegate.
+    /// </summary>
+    /// <typeparam name="TLeft">The type of the left argument.</typeparam>
+    /// <typeparam name="TRight">The type of the right argument.</typeparam>
+    /// <typeparam name="TResult">The return type of the operation.</typeparam>
+    /// <param name="operatorType">The type of expression.</param>
+    /// <param name="function">The resulting <see cref="Func{T1, T2, TResult}"/>.</param>
+    /// <param name="validationError">If the operation failed, the error.</param>
+    /// <returns><see langword="true"/> if the operation was successful; otherwise, <see langword="false"/>.</returns>
     public static bool TryGenerateLinqDelegate<TLeft, TRight, TResult>(ExpressionType operatorType, out Func<TLeft, TRight, TResult> function, out ValidationError validationError)
     {
         function = null;

--- a/src/UiPath.Workflow.Runtime/Expressions/Decrement.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/Decrement.cs
@@ -1,24 +1,5 @@
-﻿//
-//  Decrement.cs
-//
-//  Author:
-//       Devin Duanne <dduanne@tafs.com>
-//
-//  Copyright (c) TAFS, LLC.
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Lesser General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Lesser General Public License for more details.
-//
-//  You should have received a copy of the GNU Lesser General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-//
+﻿// This file is part of Core WF which is licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
 
 using System.Activities.Validation;
 using System.Linq.Expressions;

--- a/src/UiPath.Workflow.Runtime/Expressions/Decrement.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/Decrement.cs
@@ -1,0 +1,76 @@
+﻿//
+//  Decrement.cs
+//
+//  Author:
+//       Devin Duanne <dduanne@tafs.com>
+//
+//  Copyright (c) TAFS, LLC.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Activities.Validation;
+using System.Linq.Expressions;
+using System.Numerics;
+
+namespace System.Activities.Expressions
+{
+    /// <summary>
+    /// A code activity which decrements a numeral.
+    /// </summary>
+    /// <typeparam name="TNumeral">A numeric value, such as <see langword="int" /> or <see langword="long" />.</typeparam>
+    public sealed class Decrement<TNumeral> : CodeActivity<TNumeral>
+#if NET7_0_OR_GREATER
+        where TNumeral : IIncrementOperators<TNumeral>
+#endif
+    {
+        private static Func<TNumeral, TNumeral>? operationFunction = null!;
+
+        /// <summary>
+        /// Gets or sets the numeral value that will be incremented.
+        /// </summary>
+        [RequiredArgument]
+        public InOutArgument<TNumeral> Numeral { get; set; } = new();
+
+        /// <inheritdoc/>
+        protected override void CacheMetadata(CodeActivityMetadata metadata)
+        {
+            UnaryExpressionHelper.OnGetArguments(metadata, Numeral);
+            EnsureOperationFunction(metadata, ref operationFunction!, ExpressionType.Decrement);
+        }
+
+        private static void EnsureOperationFunction
+        (
+            CodeActivityMetadata metadata,
+            ref Func<TNumeral, TNumeral> operationFunction,
+            ExpressionType operatorType
+        )
+        {
+            if (operationFunction is null)
+            {
+                if (!UnaryExpressionHelper.TryGenerateLinqDelegate(operatorType, out operationFunction!, out ValidationError? validationError))
+                {
+                    metadata.AddValidationError(validationError);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override TNumeral Execute(CodeActivityContext context)
+        {
+            TNumeral value = Numeral.Get(context);
+            return operationFunction!.Invoke(value);
+        }
+    }
+}

--- a/src/UiPath.Workflow.Runtime/Expressions/Increment.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/Increment.cs
@@ -1,0 +1,76 @@
+﻿//
+//  Increment.cs
+//
+//  Author:
+//       Devin Duanne <dduanne@tafs.com>
+//
+//  Copyright (c) TAFS, LLC.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Activities.Validation;
+using System.Linq.Expressions;
+using System.Numerics;
+
+namespace System.Activities.Expressions
+{
+    /// <summary>
+    /// A code activity which increments a numeral.
+    /// </summary>
+    /// <typeparam name="TNumeral">A numeric value, such as <see langword="int" /> or <see langword="long" />.</typeparam>
+    public sealed class Increment<TNumeral> : CodeActivity<TNumeral>
+#if NET7_0_OR_GREATER
+        where TNumeral : IIncrementOperators<TNumeral>
+#endif
+    {
+        private static Func<TNumeral, TNumeral>? operationFunction = null!;
+
+        /// <summary>
+        /// Gets or sets the numeral value that will be incremented.
+        /// </summary>
+        [RequiredArgument]
+        public InOutArgument<TNumeral> Numeral { get; set; } = new();
+
+        /// <inheritdoc/>
+        protected override void CacheMetadata(CodeActivityMetadata metadata)
+        {
+            UnaryExpressionHelper.OnGetArguments<TNumeral>(metadata, Numeral);
+            EnsureOperationFunction(metadata, ref operationFunction!, ExpressionType.Increment);
+        }
+
+        private static void EnsureOperationFunction
+        (
+            CodeActivityMetadata metadata,
+            ref Func<TNumeral, TNumeral> operationFunction,
+            ExpressionType operatorType
+        )
+        {
+            if (operationFunction is null)
+            {
+                if (!UnaryExpressionHelper.TryGenerateLinqDelegate(operatorType, out operationFunction!, out ValidationError? validationError))
+                {
+                    metadata.AddValidationError(validationError);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override TNumeral Execute(CodeActivityContext context)
+        {
+            TNumeral value = Numeral.Get(context);
+            return operationFunction!.Invoke(value);
+        }
+    }
+}

--- a/src/UiPath.Workflow.Runtime/Expressions/Increment.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/Increment.cs
@@ -1,24 +1,5 @@
-﻿//
-//  Increment.cs
-//
-//  Author:
-//       Devin Duanne <dduanne@tafs.com>
-//
-//  Copyright (c) TAFS, LLC.
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Lesser General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Lesser General Public License for more details.
-//
-//  You should have received a copy of the GNU Lesser General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-//
+﻿// This file is part of Core WF which is licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
 
 using System.Activities.Validation;
 using System.Linq.Expressions;

--- a/src/UiPath.Workflow.Runtime/Expressions/SubtractAssign.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/SubtractAssign.cs
@@ -1,0 +1,117 @@
+﻿//
+//  SubtractAssign.cs
+//
+//  Author:
+//       Devin Duanne <dduanne@tafs.com>
+//
+//  Copyright (c) TAFS, LLC.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Activities.Validation;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Numerics;
+
+namespace System.Activities.Expressions
+{
+    /// <summary>
+    /// A code activity which deccrementally assigns a numeral.
+    /// </summary>
+    /// <example>
+    /// int myNum = 5;
+    /// myNum += 5; // 10.
+    /// </example>
+    /// <typeparam name="TLeft">The operand to modify.</typeparam>
+    /// <typeparam name="TRight">The operand with which to modify <typeparamref name="TLeft"/>.</typeparam>
+    /// <typeparam name="TResult">The resulting type of hte operation.</typeparam>
+    public sealed class SubtractAssign<TLeft, TRight, TResult> : CodeActivity<TResult>
+#if NET7_0_OR_GREATER
+        where TLeft : INumber<TLeft>
+        where TRight : INumber<TRight>
+        where TResult : INumber<TResult>
+#endif
+    {
+        private static Func<TLeft, TRight, TResult>? checkedOperationFunction = null;
+        private static Func<TLeft, TRight, TResult>? uncheckedOperationFunction = null;
+
+        /// <summary>
+        /// Gets or sets the left operand which will be modified by this operation.
+        /// </summary>
+        [RequiredArgument]
+        public InArgument<TLeft> Left { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the right operand which will be the modifier for this operation.
+        /// </summary>
+        [RequiredArgument]
+        public InArgument<TRight> Right { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this operation will happen in a checked or unchecked context.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool IsChecked { get; set; } = true;
+
+        /// <inheritdoc/>
+        protected override void CacheMetadata(CodeActivityMetadata metadata)
+        {
+            BinaryExpressionHelper.OnGetArguments(metadata, Left, Right);
+
+            if (IsChecked)
+            {
+                EnsureOperationFunction(metadata, ref checkedOperationFunction, ExpressionType.SubtractAssignChecked);
+            }
+            else
+            {
+                EnsureOperationFunction(metadata, ref uncheckedOperationFunction, ExpressionType.SubtractAssign);
+            }
+        }
+
+        private static void EnsureOperationFunction
+        (
+            CodeActivityMetadata metadata,
+            ref Func<TLeft, TRight, TResult>? operationFunction,
+            ExpressionType operatorType
+        )
+        {
+            if (operationFunction == null)
+            {
+                if (!BinaryExpressionHelper.TryGenerateLinqDelegate(
+                    operatorType,
+                    out operationFunction,
+                    out ValidationError? validationError))
+                {
+                    metadata.AddValidationError(validationError);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override TResult Execute(CodeActivityContext context)
+        {
+            TLeft leftValue = Left.Get(context);
+            TRight rightValue = Right.Get(context);
+
+            // If user changed checked flag between open and execution, an NRE may be thrown.
+            // This is by design.
+            // Nullability check silenced because the corresponding value is guaranteed to be
+            // non-null
+            return IsChecked
+                ? checkedOperationFunction!(leftValue, rightValue)
+                : uncheckedOperationFunction!(leftValue, rightValue);
+        }
+    }
+}

--- a/src/UiPath.Workflow.Runtime/Expressions/SubtractAssign.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/SubtractAssign.cs
@@ -1,24 +1,5 @@
-﻿//
-//  SubtractAssign.cs
-//
-//  Author:
-//       Devin Duanne <dduanne@tafs.com>
-//
-//  Copyright (c) TAFS, LLC.
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Lesser General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Lesser General Public License for more details.
-//
-//  You should have received a copy of the GNU Lesser General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-//
+﻿// This file is part of Core WF which is licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
 
 using System.Activities.Validation;
 using System.ComponentModel;

--- a/src/UiPath.Workflow.Runtime/Expressions/UnaryExpressionHelper.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/UnaryExpressionHelper.cs
@@ -8,8 +8,17 @@ using System.Linq.Expressions;
 
 namespace System.Activities.Expressions;
 
-internal static class UnaryExpressionHelper
+/// <summary>
+/// Helpers for unary expressions.
+/// </summary>
+public static class UnaryExpressionHelper
 {
+    /// <summary>
+    /// Binds the metadata for the argument.
+    /// </summary>
+    /// <typeparam name="TOperand">The type of the argument.</typeparam>
+    /// <param name="metadata">The metadata.</param>
+    /// <param name="operand">The argument.</param>
     public static void OnGetArguments<TOperand>(CodeActivityMetadata metadata, InArgument<TOperand> operand)
     {
         RuntimeArgument operandArgument = new("Operand", typeof(TOperand), ArgumentDirection.In, true);
@@ -22,6 +31,33 @@ internal static class UnaryExpressionHelper
             });
     }
 
+    /// <summary>
+    /// Binds the metadata for the argument.
+    /// </summary>
+    /// <typeparam name="TOperand">The type of the argument.</typeparam>
+    /// <param name="metadata">The metadata.</param>
+    /// <param name="operand">The argument.</param>
+    public static void OnGetArguments<TOperand>(CodeActivityMetadata metadata, InOutArgument<TOperand> operand)
+    {
+        RuntimeArgument operandArgument = new("Operand", typeof(TOperand), ArgumentDirection.InOut, true);
+        metadata.Bind(operand, operandArgument);
+
+        metadata.SetArgumentsCollection(
+            new Collection<RuntimeArgument>
+            {
+                operandArgument
+            });
+    }
+
+    /// <summary>
+    /// Generates a <see cref="System.Linq"/> delegate.
+    /// </summary>
+    /// <typeparam name="TOperand">The type of the argument.</typeparam>
+    /// <typeparam name="TResult">The return type of the operation.</typeparam>
+    /// <param name="operatorType">The type of expression.</param>
+    /// <param name="function">The resulting <see cref="Func{T1, T2, TResult}"/>.</param>
+    /// <param name="validationError">If the operation failed, the error.</param>
+    /// <returns><see langword="true"/> if the operation was successful; otherwise, <see langword="false"/>.</returns>
     public static bool TryGenerateLinqDelegate<TOperand, TResult>(ExpressionType operatorType, out Func<TOperand, TResult> operation, out ValidationError validationError)
     {
         operation = null;


### PR DESCRIPTION
Also promotes my Increment/Decrement and AddAssign/SubtractAssign expressions.

My added expressions are fully documented and ready for NET7. IfDefs can be removed if this is not desired.

Code also assumes a nullable context. I invite discussion on whether to remove nullable annotations or whether to enable nullable. I personally find it is more clear to the developer but this can be removed if requested.

All of these expressions expect numeric types (with appropriate constraints in Net7). In net6, theoretically any type would be allowed, but non-numeric types will throw. This is by design. The expressions simply provide activities for common C# operations.

`Increment` = `number++`
`Decrement` = `number--`
`AddAssign` = `number += otherNumber`
`SubtractAssign` = `number -= otherNumber`

If anyone knows how to add the designer files for these activities, please do let me know. I have been unable to figure out how to do this in Net6 and newer as PresentationCore does not seem to have been ported.

Edit: Fixes #288 