### PR TITLE
Added UpdateExpressionText to ITextExpression (VisualBasic code duplication for CSharp)

### DIFF
--- a/src/UiPath.Workflow.Runtime/Expressions/ITextExpression.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/ITextExpression.cs
@@ -7,15 +7,11 @@ namespace System.Activities.Expressions;
 
 public interface ITextExpression
 {
-    string ExpressionText
-    {
-        get;
-    }
+    string Language { get; }
 
-    string Language
-    {
-        get;
-    }
+    string ExpressionText { get; }
+
+    bool UpdateExpressionText(string expressionText);
 
     Expression GetExpressionTree();
 }

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpValue.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpValue.cs
@@ -3,13 +3,15 @@
 
 using System;
 using System.Activities;
+using System.Activities.ExpressionParser;
 using System.Activities.Expressions;
 using System.Activities.Internals;
-using System.Activities.Validation;
+using System.Activities.Runtime;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Windows.Markup;
+using ActivityContext = System.Activities.ActivityContext;
 
 namespace Microsoft.CSharp.Activities;
 
@@ -17,24 +19,94 @@ namespace Microsoft.CSharp.Activities;
 [ContentProperty("ExpressionText")]
 public class CSharpValue<TResult> : TextExpressionBase<TResult>
 {
+    private Func<ActivityContext, TResult> _compiledExpression;
+    private Expression<Func<ActivityContext, TResult>> _expressionTree;
     private CompiledExpressionInvoker _invoker;
 
     public CSharpValue() => UseOldFastPath = true;
 
     public CSharpValue(string expressionText) : this() => ExpressionText = expressionText;
 
-    public override string ExpressionText { get; set; }
-
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public override string Language => CSharpHelper.Language;
 
-    public override Expression GetExpressionTree() => IsMetadataCached ? _invoker.GetExpressionTree() : throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
+    public override string ExpressionText { get; set; }
+
+    public override bool UpdateExpressionText(string expressionText)
+    {
+        base.UpdateExpressionText(expressionText);
+        _compiledExpression = null;
+        CompileExpressionTree();
+        return _expressionTree != null;
+    }
+
+    public override Expression GetExpressionTree()
+    {
+        CheckIsMetadataCached();
+
+        if (_expressionTree == null)
+        {
+            if (_invoker != null)
+                return _invoker.GetExpressionTree();
+
+            // it's safe to create this CodeActivityMetadata here,
+            // because we know we are using it only as lookup purpose.
+            CompileExpressionTree();
+        }
+        Fx.Assert(_expressionTree.NodeType == ExpressionType.Lambda, "Lambda expression required");
+        return ExpressionUtilities.RewriteNonCompiledExpressionTree(_expressionTree);
+    }
+
+    private void CompileExpressionTree()
+    {
+        var metadata = new CodeActivityMetadata(this, GetParentEnvironment(), false);
+        var publicAccessor = CodeActivityPublicEnvironmentAccessor.CreateWithoutArgument(metadata);
+        try
+        {
+            _expressionTree = CSharpHelper.Compile<TResult>(ExpressionText, publicAccessor, false);
+        }
+        catch (SourceExpressionException e)
+        {
+            throw FxTrace.Exception.AsError(
+                new InvalidOperationException(SR.ExpressionTamperedSinceLastCompiled(e.Message)));
+        }
+        finally
+        {
+            metadata.Dispose();
+        }
+    }
+
+    public bool CanConvertToString(IValueSerializerContext context) => true;
+
+    public string ConvertToString(IValueSerializerContext context) => "[" + ExpressionText + "]";
+
+    protected override TResult Execute(CodeActivityContext context)
+    {
+        if (_expressionTree == null)
+        {
+            return (TResult)_invoker.InvokeExpression(context);
+        }
+        _compiledExpression ??= _expressionTree.Compile();
+        return _compiledExpression(context);
+    }
 
     protected override void CacheMetadata(CodeActivityMetadata metadata)
     {
+        _expressionTree = null;
         _invoker = new CompiledExpressionInvoker(this, false, metadata);
-        QueueForValidation<TResult>(metadata, false);
-    }
 
-    protected override TResult Execute(CodeActivityContext context) => (TResult) _invoker.InvokeExpression(context);
+        if (QueueForValidation<TResult>(metadata, false))
+        {
+            return;
+        }
+        try
+        {
+            var publicAccessor = CodeActivityPublicEnvironmentAccessor.Create(metadata);
+            _expressionTree = CSharpHelper.Compile<TResult>(ExpressionText, publicAccessor, false);
+        }
+        catch (SourceExpressionException e)
+        {
+            metadata.AddValidationError(e.Message);
+        }
+    }
 }

--- a/src/UiPath.Workflow/Microsoft/TextExpressionBase.cs
+++ b/src/UiPath.Workflow/Microsoft/TextExpressionBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.Activities.Expressions;
+using System.Activities.Internals;
 using System.Activities.Validation;
 using System.Linq.Expressions;
 
@@ -11,6 +12,13 @@ namespace System.Activities
         public abstract string ExpressionText { get; set; }
 
         public abstract string Language { get; }
+
+        public virtual bool UpdateExpressionText(string expressionText)
+        {
+            CheckIsMetadataCached();
+            ExpressionText = expressionText;
+            return true;
+        }
 
         public abstract Expression GetExpressionTree();
 
@@ -36,6 +44,12 @@ namespace System.Activities
                 return true;
             }
             return false;
+        }
+
+        protected void CheckIsMetadataCached()
+        {
+            if (!IsMetadataCached)
+                throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
         }
     }
 }


### PR DESCRIPTION
Added UpdateExpressionText to ITextExpression with minimum changes and lots of code duplication

CSharpValue/Reference classes are code duplication after VisualBasicValue/Reference classes