### PR TITLE
feat: provide diagnostics to StudioWeb

### DIFF
--- a/src/UiPath.Workflow/Activities/ScriptingAotCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingAotCompiler.cs
@@ -85,7 +85,8 @@ public abstract class ScriptingAotCompiler : AheadOfTimeCompiler
             SourceLineNumber = diagnostic.Location.GetMappedLineSpan().StartLinePosition.Line,
             Number = diagnostic.Id,
             Message = diagnostic.ToString(),
-            IsWarning = diagnostic.Severity < DiagnosticSeverity.Error
+            IsWarning = diagnostic.Severity < DiagnosticSeverity.Error,
+            Diagnostic = diagnostic // used by Studio Web through reflection
         }));
     }
 

--- a/src/UiPath.Workflow/XamlIntegration/TextExpressionCompilerError.cs
+++ b/src/UiPath.Workflow/XamlIntegration/TextExpressionCompilerError.cs
@@ -1,6 +1,8 @@
 // This file is part of Core WF which is licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
+
 namespace System.Activities.XamlIntegration;
 
 [Serializable]
@@ -15,6 +17,10 @@ public class TextExpressionCompilerError
     public string Message { get; internal set; }
 
     public string Number { get; internal set; }
+
+    // To be used with reflection in Studio Web
+    // marked as internal so it's not referenced in wrong places
+    internal Diagnostic Diagnostic { get; set; }
 
     public override string ToString()
     {


### PR DESCRIPTION
In order to highlight the issue in Expression Editor we will need more details from the compiler. 
This details are available in the diagnostics model and we decided to map the entire object in case we need something in the future. The property is marked as internal so it's not referenced in wrong places.