### PR TITLE
Make sure expressions end even if they left a quote open

### DIFF
--- a/src/UiPath.Workflow/Validation/CSharpExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/CSharpExpressionValidator.cs
@@ -16,9 +16,12 @@ namespace System.Activities.Validation;
 /// </summary>
 public class CSharpExpressionValidator : RoslynExpressionValidator
 {
-    private const string _valueValidationTemplate = "public static System.Linq.Expressions.Expression<System.Func<{0}>> CreateExpression{1}() => ({2}) => {3};//activityId:{4}";
-    private const string _delegateValueValidationTemplate = "{0}\npublic static System.Linq.Expressions.Expression<{1}<{2}>> CreateExpression{3}() => ({4}) => {5};//activityId:{6}";
-    private const string _referenceValidationTemplate = "public static {0} IsLocation{1}() => ({2}) => {3} = default({4});//activityId:{5}";
+    // This is used in case the expression does not properly close (e.g. missing quotes, or multiline comment not closed)
+    private const string _expressionEnder = "// */ // \"";
+
+    private const string _valueValidationTemplate = "public static System.Linq.Expressions.Expression<System.Func<{0}>> CreateExpression{1}()//activityId:{4}\n => ({2}) => {3}; {5}";
+    private const string _delegateValueValidationTemplate = "{0}\npublic static System.Linq.Expressions.Expression<{1}<{2}>> CreateExpression{3}()//activityId:{6}\n => ({4}) => {5}; {7}";
+    private const string _referenceValidationTemplate = "public static {0} IsLocation{1}()//activityId:{5}\n => ({2}) => {3} = default({4}); {6}";
 
     private static readonly Lazy<CSharpExpressionValidator> s_instance = new(() => new());
     public override string Language => CSharpHelper.Language;
@@ -54,10 +57,10 @@ public class CSharpExpressionValidator : RoslynExpressionValidator
     {
         var arrayType = types.Split(",");
         if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
-            return string.Format(_valueValidationTemplate, types, index, names, code, activityId);
+            return string.Format(_valueValidationTemplate, types, index, names, code, activityId, _expressionEnder);
 
         var (myDelegate, name) = CompilerHelper.DefineDelegate(types);
-        return string.Format(_delegateValueValidationTemplate, myDelegate, name, types, index, names, code, activityId);
+        return string.Format(_delegateValueValidationTemplate, myDelegate, name, types, index, names, code, activityId, _expressionEnder);
     }
 
     protected override string CreateReferenceCode(string types, string names, string code, string activityId, string returnType, int index)
@@ -65,7 +68,7 @@ public class CSharpExpressionValidator : RoslynExpressionValidator
         var actionDefinition = !string.IsNullOrWhiteSpace(types)
             ? $"Action<{string.Join(Comma, types)}>"
             : "Action";
-        return string.Format(_referenceValidationTemplate, actionDefinition, index, names, code, returnType, activityId);
+        return string.Format(_referenceValidationTemplate, actionDefinition, index, names, code, returnType, activityId, _expressionEnder);
     }
 
     protected override SyntaxTree GetSyntaxTreeForExpression(string expressionText) =>

--- a/src/UiPath.Workflow/Validation/VBExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/VBExpressionValidator.cs
@@ -17,9 +17,11 @@ public class VbExpressionValidator : RoslynExpressionValidator
 {
     private static readonly Lazy<VbExpressionValidator> s_instance = new(() => new());
 
-    private const string _valueValidationTemplate = "Public Shared Function CreateExpression{0}() As System.Linq.Expressions.Expression(Of System.Func(Of {1}))'activityId:{4}\nReturn Function({2}) ({3})'activityId:{4}\nEnd Function";
-    private const string _delegateValueValidationTemplate = "{0}\nPublic Shared Function CreateExpression{1}() As System.Linq.Expressions.Expression(Of {2}(Of {3}))'activityId:{6}\nReturn Function({4}) ({5})'activityId:{6}\nEnd Function";
-    private const string _referenceValidationTemplate = "Public Shared Function IsLocation{0}() As {1}'activityId:{5}\nReturn Function({2}) as System.Action'activityId:{5}\nReturn Sub() {3} = CType(Nothing, {4})'activityId:{5}\nEnd Function'activityId:{5}\nEnd Function";
+    // This is used in case the expression does not properly close (missing quote)
+    private const string _expressionEnder = "'\"";
+    private const string _valueValidationTemplate = "Public Shared Function CreateExpression{0}() As System.Linq.Expressions.Expression(Of System.Func(Of {1}))'activityId:{4}\nReturn Function({2}) ({3}) {5}\nEnd Function";
+    private const string _delegateValueValidationTemplate = "{0}\nPublic Shared Function CreateExpression{1}() As System.Linq.Expressions.Expression(Of {2}(Of {3}))'activityId:{6}\nReturn Function({4}) ({5}){7}\nEnd Function";
+    private const string _referenceValidationTemplate = "Public Shared Function IsLocation{0}() As {1}'activityId:{5}\nReturn Function({2}) as System.Action\nReturn Sub() {3} = CType(Nothing, {4}){6}\nEnd Function\nEnd Function";
 
     /// <summary>
     ///     Initializes the MetadataReference collection.
@@ -64,10 +66,10 @@ public class VbExpressionValidator : RoslynExpressionValidator
     {
         var arrayType = types.Split(",");
         if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
-            return string.Format(_valueValidationTemplate, index, types, names, code, activityId);
+            return string.Format(_valueValidationTemplate, index, types, names, code, activityId, _expressionEnder);
 
         var (myDelegate, name) = CompilerHelper.DefineDelegate(types);
-        return string.Format(_delegateValueValidationTemplate, myDelegate, index, name, types, names, code, activityId);
+        return string.Format(_delegateValueValidationTemplate, myDelegate, index, name, types, names, code, activityId, _expressionEnder);
     }
 
     protected override string CreateReferenceCode(string types, string names, string code, string activityId, string returnType, int index)
@@ -75,6 +77,6 @@ public class VbExpressionValidator : RoslynExpressionValidator
         var actionDefinition = !string.IsNullOrWhiteSpace(types)
             ? $"Action(Of {string.Join(Comma, types)})"
             : "Action";
-        return string.Format(_referenceValidationTemplate, index, actionDefinition, names, code, returnType, activityId);
+        return string.Format(_referenceValidationTemplate, index, actionDefinition, names, code, returnType, activityId, _expressionEnder);
     }
 }


### PR DESCRIPTION
Such as:
VB: it does have even number of quotes
C#: it does not have unclosed multiline text or comment. Before the fix, when it had such situations, it would fail the whole validation for the file, making it impossible to pinpoint the actual error and fix it.
See https://uipath.atlassian.net/browse/STUD-67676 for more details