### PR TITLE
Activity RefreshActitivityTree

### DIFF
--- a/src/UiPath.Workflow.Runtime/Activity.cs
+++ b/src/UiPath.Workflow.Runtime/Activity.cs
@@ -84,7 +84,11 @@ public abstract partial class Activity
         }
     }
 
-    protected internal int CacheId => _cacheId;
+    protected internal int CacheId
+    {
+        get => _cacheId;
+        set => _cacheId = value;
+    }
 
     internal RelationshipType RelationshipToParent => _relationshipToParent;
 

--- a/src/UiPath.Workflow.Runtime/ActivityInstance.cs
+++ b/src/UiPath.Workflow.Runtime/ActivityInstance.cs
@@ -57,6 +57,8 @@ public sealed class ActivityInstance
         ImplementationVersion = activity.ImplementationVersion;
     }
 
+    internal int DelegateParameterCount { get; set; }
+
     /// <summary>
     /// The values of the out arguments.
     /// </summary>
@@ -709,6 +711,7 @@ public sealed class ActivityInstance
         _parent = parent;
         _instanceMap = instanceMap;
         _id = instanceId;
+        DelegateParameterCount = delegateParameterCount;
 
         if (_instanceMap != null)
         {

--- a/src/UiPath.Workflow.Runtime/ActivityUtilities.cs
+++ b/src/UiPath.Workflow.Runtime/ActivityUtilities.cs
@@ -799,7 +799,7 @@ internal static class ActivityUtilities
 
     private static bool ShouldShortcut(Activity activity, ProcessActivityTreeOptions options) => options.SkipIfCached && options.IsRuntimeReadyOptions && activity.IsRuntimeReady;
 
-    private static void ProcessActivityTreeCore(ChildActivity currentActivity, ActivityCallStack parentChain, ProcessActivityTreeOptions options, ProcessActivityCallback callback, ref IList<ValidationError> validationErrors)
+    internal static void ProcessActivityTreeCore(ChildActivity currentActivity, ActivityCallStack parentChain, ProcessActivityTreeOptions options, ProcessActivityCallback callback, ref IList<ValidationError> validationErrors)
     {
         Fx.Assert(options != null, "We need you to explicitly specify options.");
         Fx.Assert(currentActivity.Activity.MemberOf != null, "We must have an activity with MemberOf setup or we need to skipIdGeneration.");

--- a/src/UiPath.Workflow/Debugger/ActivityExtensions.cs
+++ b/src/UiPath.Workflow/Debugger/ActivityExtensions.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Activities;
+using System.Activities.Runtime;
+using System.Activities.Tracking;
+using System.Activities.Validation;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UiPath.Workflow.Debugger;
+
+public static class ActivityExtensions
+{
+    /// <summary>
+    /// A client may change properties at runtime (while execution is paused),
+    /// and so, based on the activity internal logic, a new call to CacheMetadata may be required.
+    /// This extension method will update the activity state.
+    /// ATTENTION - calling this method will generate a new activity.Id
+    /// </summary>
+    /// <returns>a list of validation errors</returns>
+    public static IList<ValidationError> RefreshActivityTree(this Activity activity)
+    {
+        if (activity == null)
+            return Array.Empty<ValidationError>();
+
+        ClearCacheIds(activity);
+        activity.ClearCachedInformation();
+
+        var options = ProcessActivityTreeOptions.FullCachingOptions;
+        IList<ValidationError> validationErrors = null;
+        var childActivity = new ActivityUtilities.ChildActivity(activity, true);
+        ActivityUtilities.ProcessActivityTreeCore(childActivity, null, options, null, ref validationErrors);
+        return validationErrors;
+    }
+
+    /// <summary>
+    /// If properties where changed at runtime while execution is paused,
+    /// by an external client than the <paramref name="activityInfo"/> environment 
+    /// needs to be updated.
+    /// </summary>
+    public static void UpdateEnvironment(this ActivityInfo activityInfo)
+        => activityInfo?.Instance?.UpdateEnvironment();
+
+    /// <summary>
+    /// While debugging the activity may call again CacheMetadata,
+    /// and the validation of RuntimeArguments may fail due to already initialized CacheIds    
+    /// </summary>
+    private static void ClearCacheIds(this Activity activity)
+    {
+        if (activity.RuntimeArguments == null)
+            return;
+
+        foreach (var item in activity
+                                .RuntimeArguments
+                                .Where(a => a?.BoundArgument?.Expression?.CacheId == activity.CacheId))
+        {
+            item.BoundArgument.Expression.CacheId = 0;
+        }
+    }
+
+    private static void UpdateEnvironment(this ActivityInstance activityInstance)
+    {
+        var newCapacity = activityInstance.Activity.SymbolCount + activityInstance.DelegateParameterCount;
+        activityInstance.Environment.EnsureCapacity(newCapacity);
+    }
+
+    private static void EnsureCapacity(this LocationEnvironment environment, int newCapacity)
+    {
+        if (environment.SerializedLocations == null
+            || newCapacity <= environment.SerializedLocations.Length)
+            return;
+
+        environment.SerializedLocations = new Location[newCapacity];
+    }
+}

--- a/src/UiPath.Workflow/Debugger/ActivityExtensions.cs
+++ b/src/UiPath.Workflow/Debugger/ActivityExtensions.cs
@@ -8,6 +8,9 @@ using System.Linq;
 
 namespace UiPath.Workflow.Debugger;
 
+/// <summary>
+/// TODO - add unit tests.
+/// </summary>
 public static class ActivityExtensions
 {
     /// <summary>
@@ -17,7 +20,7 @@ public static class ActivityExtensions
     /// ATTENTION - calling this method will generate a new activity.Id
     /// </summary>
     /// <returns>a list of validation errors</returns>
-    public static IList<ValidationError> RefreshActivityTree(this Activity activity)
+    public static IList<ValidationError> RefreshCacheMetadata(this Activity activity)
     {
         if (activity == null)
             return Array.Empty<ValidationError>();


### PR DESCRIPTION
A client may change properties at runtime (while execution is paused), operation which requires a new call to CacheMetadata.
The Activity.RefreshActivityTree extension method provides this functionality.

https://uipath.atlassian.net/wiki/spaces/STUD/pages/87546724494/Hot+Reload+Investigation