### PR TITLE
Use AssemblyReferences instead of AssemblyNames for validation

### DIFF
--- a/src/Perf/CoreWf.Benchmarks/ExpressionTextboxPerformance.cs
+++ b/src/Perf/CoreWf.Benchmarks/ExpressionTextboxPerformance.cs
@@ -2,6 +2,8 @@
 using Microsoft.CSharp.Activities;
 using Microsoft.VisualBasic.Activities;
 using System.Activities;
+using System.Activities.Expressions;
+using System.Reflection;
 
 namespace CoreWf.Benchmarks
 {
@@ -27,13 +29,13 @@ namespace CoreWf.Benchmarks
         [Benchmark]
         public async Task CS_CreatePrecompiledValueAsync()
         {
-            await CSharpDesignerHelper.CreatePrecompiledValueAsync(typeof(object), $"1 + {index++}", new[] { "System" }, new[] { "System" }, GetFreshEnvironment);
+            await CSharpDesignerHelper.CreatePrecompiledValueAsync(typeof(object), $"1 + {index++}", new[] { "System" }, new[] { (AssemblyReference)new AssemblyName("System") }, GetFreshEnvironment);
         }
 
         [Benchmark]
         public async Task VB_CreatePrecompiledValueAsync()
         {
-            await VisualBasicDesignerHelper.CreatePrecompiledValueAsync(typeof(object), $"1 + {index++}", new[] { "System" }, new[] { "System" }, GetFreshEnvironment);
+            await VisualBasicDesignerHelper.CreatePrecompiledValueAsync(typeof(object), $"1 + {index++}", new[] { "System" }, new[] { (AssemblyReference)new AssemblyName("System") }, GetFreshEnvironment);
         }
     }
 }

--- a/src/Test/TestCases.Workflows/XamlTests.cs
+++ b/src/Test/TestCases.Workflows/XamlTests.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -228,7 +229,7 @@ namespace TestCases.Workflows
 
         [Theory]
         [MemberData(nameof(GetCSharpTestData))]
-        public async Task CS_CreatePrecompiledValueAsync(string expression, IEnumerable<string> namespaces, IEnumerable<string> assemblies, IEnumerable<VisualBasicImportReference> importReferences)
+        public async Task CS_CreatePrecompiledValueAsync(string expression, IEnumerable<string> namespaces, IEnumerable<AssemblyReference> assemblies, IEnumerable<VisualBasicImportReference> importReferences)
         {
             var result = await CSharpDesignerHelper.CreatePrecompiledValueAsync(null, expression, namespaces, assemblies, null);
 
@@ -240,7 +241,7 @@ namespace TestCases.Workflows
 
         [Theory]
         [MemberData(nameof(GetVBTestData))]
-        public async Task VB_CreatePrecompiledValueAsync(string expression, IEnumerable<string> namespaces, IEnumerable<string> assemblies, IEnumerable<VisualBasicImportReference> importReferences)
+        public async Task VB_CreatePrecompiledValueAsync(string expression, IEnumerable<string> namespaces, IEnumerable<AssemblyReference> assemblies, IEnumerable<VisualBasicImportReference> importReferences)
         {
             var result = await VisualBasicDesignerHelper.CreatePrecompiledValueAsync(null, expression, namespaces, assemblies, null);
 
@@ -254,10 +255,11 @@ namespace TestCases.Workflows
         {
             get
             {
-                yield return new object[] { "typeof(JsonConvert)", new[] { "Newtonsoft.Json" }, new[] { "Newtonsoft.Json" }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
-                yield return new object[] { "new JToken[5]", new[] { "Newtonsoft.Json", "Newtonsoft.Json.Linq" }, new[] { "Newtonsoft.Json" }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
-                yield return new object[] { "new Dictionary<Dictionary<JToken, string>, JToken>()", new[] { "System.Collections.Generic", "Newtonsoft.Json", "Newtonsoft.Json.Linq" }, new[] { "Newtonsoft.Json" }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
-                yield return new object[] { "new ClassWithDictionaryProperty().TestProperty", new[] { "TestCases.Workflows" }, new[] { "System.Collections", "TestCases.Workflows", }, new[] { new VisualBasicImportReference { Assembly = "TestCases.Workflows", Import = "TestCases.Workflows" }, new VisualBasicImportReference { Assembly = "System.Private.CoreLib", Import = "System.Collections" } } };
+                yield return new object[] { "typeof(JsonConvert)", new[] { "Newtonsoft.Json" }, new[] { (AssemblyReference)new AssemblyName("Newtonsoft.Json") }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
+                yield return new object[] { "typeof(JsonConvert)", new[] { "Newtonsoft.Json" }, new[] { (AssemblyReference)typeof(JsonToken).Assembly }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
+                yield return new object[] { "new JToken[5]", new[] { "Newtonsoft.Json", "Newtonsoft.Json.Linq" }, new[] { (AssemblyReference)new AssemblyName("Newtonsoft.Json") }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
+                yield return new object[] { "new Dictionary<Dictionary<JToken, string>, JToken>()", new[] { "System.Collections.Generic", "Newtonsoft.Json", "Newtonsoft.Json.Linq" }, new[] { (AssemblyReference)new AssemblyName("Newtonsoft.Json") }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
+                yield return new object[] { "new ClassWithDictionaryProperty().TestProperty", new[] { "TestCases.Workflows" }, new[] { (AssemblyReference)new AssemblyName("System.Collections"), (AssemblyReference)new AssemblyName("TestCases.Workflows") }, new[] { new VisualBasicImportReference { Assembly = "TestCases.Workflows", Import = "TestCases.Workflows" }, new VisualBasicImportReference { Assembly = "System.Private.CoreLib", Import = "System.Collections" } } };
             }
         }
 
@@ -265,10 +267,11 @@ namespace TestCases.Workflows
         {
             get
             {
-                yield return new object[] { "GetType(JsonConvert)", new[] { "Newtonsoft.Json" }, new[] { "Newtonsoft.Json" }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
-                yield return new object[] { "new JToken(5){}", new[] { "Newtonsoft.Json", "Newtonsoft.Json.Linq" }, new[] { "Newtonsoft.Json" }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
-                yield return new object[] { "new Dictionary(Of Dictionary(Of JToken, String), JToken)()", new[] { "System.Collections.Generic", "Newtonsoft.Json", "Newtonsoft.Json.Linq" }, new[] { "Newtonsoft.Json" }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
-                yield return new object[] { "new ClassWithDictionaryProperty().TestProperty", new[] { "TestCases.Workflows" }, new[] { "System.Collections", "TestCases.Workflows", }, new[] { new VisualBasicImportReference { Assembly = "TestCases.Workflows", Import = "TestCases.Workflows" }, new VisualBasicImportReference { Assembly = "System.Private.CoreLib", Import = "System.Collections" } } };
+                yield return new object[] { "GetType(JsonConvert)", new[] { "Newtonsoft.Json" }, new[] { (AssemblyReference)new AssemblyName("Newtonsoft.Json") }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
+                yield return new object[] { "GetType(JsonConvert)", new[] { "Newtonsoft.Json" }, new[] { (AssemblyReference)typeof(JsonToken).Assembly }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
+                yield return new object[] { "new JToken(5){}", new[] { "Newtonsoft.Json", "Newtonsoft.Json.Linq" }, new[] { (AssemblyReference)new AssemblyName("Newtonsoft.Json") }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
+                yield return new object[] { "new Dictionary(Of Dictionary(Of JToken, String), JToken)()", new[] { "System.Collections.Generic", "Newtonsoft.Json", "Newtonsoft.Json.Linq" }, new[] { (AssemblyReference)new AssemblyName("Newtonsoft.Json") }, new[] { new VisualBasicImportReference { Assembly = "Newtonsoft.Json", Import = "Newtonsoft.json" } } };
+                yield return new object[] { "new ClassWithDictionaryProperty().TestProperty", new[] { "TestCases.Workflows" }, new[] { (AssemblyReference)new AssemblyName("System.Collections"), (AssemblyReference)new AssemblyName("TestCases.Workflows") }, new[] { new VisualBasicImportReference { Assembly = "TestCases.Workflows", Import = "TestCases.Workflows" }, new VisualBasicImportReference { Assembly = "System.Private.CoreLib", Import = "System.Collections" } } };
             }
         }
 

--- a/src/UiPath.Workflow/Activities/ExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ExpressionCompiler.cs
@@ -12,10 +12,10 @@ namespace System.Activities
 {
     internal abstract class ExpressionCompiler
     {
-        public Compilation Compile(string expressionText, bool isLocation, Type returnType, IReadOnlyCollection<string> namespaces, IReadOnlyCollection<string> referencedAssemblies, LocationReferenceEnvironment environment)
+        public Compilation Compile(string expressionText, bool isLocation, Type returnType, IReadOnlyCollection<string> namespaces, IReadOnlyCollection<AssemblyReference> referencedAssemblies, LocationReferenceEnvironment environment)
         {
             var syntaxTree = GetSyntaxTreeForExpression(expressionText, isLocation, returnType, environment);
-            return GetCompilation(JitCompilerHelper.DefaultReferencedAssemblies.Select(a => AssemblyReference.GetFastAssemblyName(a).Name).Union(referencedAssemblies).ToList(), namespaces).AddSyntaxTrees(syntaxTree);
+            return GetCompilation(JitCompilerHelper.DefaultReferencedAssemblies.Select(a => (AssemblyReference)a).Union(referencedAssemblies).ToList(), namespaces).AddSyntaxTrees(syntaxTree);
         }
 
         public abstract Type GetReturnType(Compilation compilation);
@@ -66,7 +66,7 @@ namespace System.Activities
             }
         }
 
-        protected abstract Compilation GetCompilation(IReadOnlyCollection<string> assemblies, IReadOnlyCollection<string> namespaces);
+        protected abstract Compilation GetCompilation(IReadOnlyCollection<AssemblyReference> assemblies, IReadOnlyCollection<string> namespaces);
 
         protected abstract SyntaxTree GetSyntaxTreeForExpression(string expression, bool isLocation, Type returnType, LocationReferenceEnvironment environment);
 

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpDesignerHelper.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpDesignerHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Activities;
 using System.Activities.ExpressionParser;
+using System.Activities.Expressions;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -13,8 +14,8 @@ namespace Microsoft.CSharp.Activities;
 
 internal class CSharpHelper : JitCompilerHelper<CSharpHelper>
 {
-    public CSharpHelper(string expressionText, HashSet<AssemblyName> refAssemNames,
-        HashSet<string> namespaceImportsNames) : base(expressionText, refAssemNames, namespaceImportsNames) { }
+    public CSharpHelper(string expressionText, HashSet<AssemblyReference> assemblyReferences,
+        HashSet<string> namespaceImportsNames) : base(expressionText, assemblyReferences, namespaceImportsNames) { }
 
     protected override JustInTimeCompiler CreateCompiler(HashSet<Assembly> references) => 
         new CSharpJitCompiler(references);
@@ -34,7 +35,7 @@ internal class CSharpDesignerHelperImpl : DesignerHelperImpl
     public override Type ExpressionFactoryType => typeof(CSharpExpressionFactory<>);
     public override string Language => CSharpHelper.Language;
 
-    public override JitCompilerHelper CreateJitCompilerHelper(string expressionText, HashSet<AssemblyName> references,
+    public override JitCompilerHelper CreateJitCompilerHelper(string expressionText, HashSet<AssemblyReference> references,
         HashSet<string> namespaces)
     {
         return new CSharpHelper(expressionText, references, namespaces);
@@ -72,8 +73,26 @@ public static class CSharpDesignerHelper
             environment, out returnType, out compileError, out vbSettings);
     }
 
+    public static Activity CreatePrecompiledValue(Type targetType, string expressionText,
+        IEnumerable<string> namespaces, IEnumerable<AssemblyReference> referencedAssemblies,
+        LocationReferenceEnvironment environment, out Type returnType, out SourceExpressionException compileError,
+        out VisualBasicSettings vbSettings)
+    {
+        return s_impl.CreatePrecompiledValue(targetType, expressionText, namespaces, referencedAssemblies,
+            environment, out returnType, out compileError, out vbSettings);
+    }
+
     public static Activity CreatePrecompiledReference(Type targetType, string expressionText,
         IEnumerable<string> namespaces, IEnumerable<string> referencedAssemblies,
+        LocationReferenceEnvironment environment, out Type returnType, out SourceExpressionException compileError,
+        out VisualBasicSettings vbSettings)
+    {
+        return s_impl.CreatePrecompiledReference(targetType, expressionText, namespaces, referencedAssemblies,
+            environment, out returnType, out compileError, out vbSettings);
+    }
+
+    public static Activity CreatePrecompiledReference(Type targetType, string expressionText,
+        IEnumerable<string> namespaces, IEnumerable<AssemblyReference> referencedAssemblies,
         LocationReferenceEnvironment environment, out Type returnType, out SourceExpressionException compileError,
         out VisualBasicSettings vbSettings)
     {
@@ -86,7 +105,6 @@ public static class CSharpDesignerHelper
     {
         return s_impl.CreatePrecompiledValue(targetType, expressionText, parent, out returnType, out compileError, out vbSettings);
     }
-
 
     public static Activity CreatePrecompiledValue(Type targetType, string expressionText, Activity parent,
         out Type returnType, out SourceExpressionException compileError)
@@ -106,9 +124,9 @@ public static class CSharpDesignerHelper
         return CreatePrecompiledReference(targetType, expressionText, parent, out returnType, out compileError, out _);
     }
 
-    public static Task<CompiledExpressionResult> CreatePrecompiledValueAsync(Type targetType, string expressionText, IEnumerable<string> namespaces, IEnumerable<string> assemblies, LocationReferenceEnvironment environment)
+    public static Task<CompiledExpressionResult> CreatePrecompiledValueAsync(Type targetType, string expressionText, IEnumerable<string> namespaces, IEnumerable<AssemblyReference> assemblies, LocationReferenceEnvironment environment)
         => s_impl.CreatePrecompiledValueAsync(targetType, expressionText, namespaces, assemblies, environment);
 
-    public static Task<CompiledExpressionResult> CreatePrecompiledReferenceAsync(Type targetType, string expressionText, IEnumerable<string> namespaces, IEnumerable<string> assemblies, LocationReferenceEnvironment environment)
+    public static Task<CompiledExpressionResult> CreatePrecompiledReferenceAsync(Type targetType, string expressionText, IEnumerable<string> namespaces, IEnumerable<AssemblyReference> assemblies, LocationReferenceEnvironment environment)
         => s_impl.CreatePrecompiledReferenceAsync(targetType, expressionText, namespaces, assemblies, environment);
 }

--- a/src/UiPath.Workflow/Microsoft/CSharp/CSharpExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/CSharpExpressionCompiler.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Activities;
+using System.Activities.Expressions;
 using System.Activities.Utils;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +16,7 @@ internal sealed class CSharpExpressionCompiler : ExpressionCompiler
 {
     private readonly CSharpCompilerHelper _compilerHelper = new();
 
-    protected override Compilation GetCompilation(IReadOnlyCollection<string> assemblies, IReadOnlyCollection<string> namespaces)
+    protected override Compilation GetCompilation(IReadOnlyCollection<AssemblyReference> assemblies, IReadOnlyCollection<string> namespaces)
     {
         var options = _compilerHelper.DefaultCompilationUnit.Options as CSharpCompilationOptions;
 

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using System;
 using System.Activities;
+using System.Activities.Expressions;
 using System.Activities.Utils;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,7 +30,7 @@ internal sealed class VisualBasicExpressionCompiler : ExpressionCompiler
         return GetSystemType(typeInfo, GetAssemblyForType(typeInfo));
     }
 
-    protected override Compilation GetCompilation(IReadOnlyCollection<string> assemblies, IReadOnlyCollection<string> namespaces)
+    protected override Compilation GetCompilation(IReadOnlyCollection<AssemblyReference> assemblies, IReadOnlyCollection<string> namespaces)
     {
         var options = _compilerHelper.DefaultCompilationUnit.Options as VisualBasicCompilationOptions;
 

--- a/src/UiPath.Workflow/Utils/MetadataReferenceUtils.cs
+++ b/src/UiPath.Workflow/Utils/MetadataReferenceUtils.cs
@@ -33,10 +33,8 @@ namespace System.Activities.Utils
             return meta;
         }
 
-        internal static IReadOnlyCollection<MetadataReference> GetMetadataReferences(IEnumerable<string> assemblyNames)
-        {
-            return GetMetadataReferences(assemblyNames.Select(a => AssemblyReference.GetAssembly(new AssemblyName(a))));
-        }
+        internal static IReadOnlyCollection<MetadataReference> GetMetadataReferences(IEnumerable<AssemblyReference> assemblyReferences)
+            => GetMetadataReferences(assemblyReferences.OfType<AssemblyReference>().Select(aref => aref.Assembly ?? LoadAssemblyFromReference(aref)));
 
         internal static IReadOnlyCollection<MetadataReference> GetMetadataReferences(IEnumerable<Assembly> assemblies)
         {
@@ -80,6 +78,18 @@ namespace System.Activities.Utils
             }
 
             return null;
+        }
+
+        /// <summary>
+        ///     If <see cref="AssemblyReference.Assembly"/> is null, loads the assembly. Default is to
+        ///     call <see cref="AssemblyReference.LoadAssembly"/>.
+        /// </summary>
+        /// <param name="assemblyReference"></param>
+        /// <returns></returns>
+        private static Assembly LoadAssemblyFromReference(AssemblyReference assemblyReference)
+        {
+            assemblyReference.LoadAssembly();
+            return assemblyReference.Assembly;
         }
     }
 }


### PR DESCRIPTION
There are two types of validation
- For the whole workflow
- For a single expression

The first one creates the compilation by using a list of `AssemblyReferences`. The second one, uses a list of `AssemblyNames` and **it either resolves them or retrieves the values from a cache**. If the platform that requires the validation already has an `AssemblyReference`, **it should be able to forward without relying on CoreWF to resolve it**. 

This PR replaces the list of `AssemblyNames` with `AssemblyReferences` and uses the same approach as the full workflow validation to resolve the `Assemblies`.