### PR TITLE
Bump signing reference

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -15,7 +15,7 @@ resources:
     - repository: templates
       type: github
       name: UiPath/AzurePipelinesTemplates
-      ref: refs/tags/uipath.package-signing.1.5.0
+      ref: refs/tags/uipath.package-signing.1.9.2
       endpoint: UiPath
 
 variables:


### PR DESCRIPTION
Older versions of the package signing template fail on new Azure Devops agents with PS 7.4.0.