### PR TITLE
fix location not found for certain expressions in vb

### DIFF
--- a/src/Test/TestCases.Workflows/XamlTests.cs
+++ b/src/Test/TestCases.Workflows/XamlTests.cs
@@ -251,6 +251,21 @@ namespace TestCases.Workflows
             }
         }
 
+        [Fact]
+        public async Task VB_CreatePrecompiedValueAsync_ProperlyIdentifiesVariables()
+        {
+            var seq = new Sequence();
+            var location = new ActivityLocationReferenceEnvironment();
+            WorkflowInspectionServices.CacheMetadata(seq, location);
+            IList<ValidationError> errors = new List<ValidationError>();
+
+            location.Declare(new Variable<string>("variable1"), seq, ref errors);
+            var result = await VisualBasicDesignerHelper.CreatePrecompiledValueAsync(typeof(string), "\"\" + variable1", null, null, location);
+            result.SourceExpressionException?.Errors.ShouldBeEmpty();
+            result.ReturnType.ShouldBe(typeof(string));
+            result.Activity.ShouldNotBeNull();
+        }
+
         public static IEnumerable<object[]> GetCSharpTestData
         {
             get

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
@@ -41,7 +41,7 @@ internal sealed class VisualBasicExpressionCompiler : ExpressionCompiler
 
     protected override SyntaxTree GetSyntaxTreeForExpression(string expression, bool isLocation, Type returnType, LocationReferenceEnvironment environment)
     {
-        var syntaxTree = VisualBasicSyntaxTree.ParseText(expression, _compilerHelper.ScriptParseOptions);
+        var syntaxTree = VisualBasicSyntaxTree.ParseText("? " + expression, _compilerHelper.ScriptParseOptions);
         var identifiers = syntaxTree.GetRoot().DescendantNodesAndSelf().Where(n => n.RawKind == (int)SyntaxKind.IdentifierName)
                                     .Select(n => n.ToString()).Distinct(_compilerHelper.IdentifierNameComparer);
         var resolvedIdentifiers = identifiers


### PR DESCRIPTION
CreatePrecompiledValueAsync will not properly parse variables, unless expression is preceded by `? ` sign.
This was missed while implementing https://github.com/UiPath/CoreWF/pull/286