### PR TITLE
Compile C# expressions on demand

### DIFF
--- a/src/Test/TestCases.Workflows/WF4Samples/Expressions.cs
+++ b/src/Test/TestCases.Workflows/WF4Samples/Expressions.cs
@@ -87,7 +87,7 @@ Iterate ArrayList
         static readonly string CSharpCalculationResult = "Result == XX^2" + Environment.NewLine;
         static readonly StringDictionary CSharpCalculationInputs = new() { ["XX"] = 16, ["YY"] = 16 };
         [Fact]
-        public void SameTextDifferentTypes()
+        public void VBSameTextDifferentTypes()
         {
             var text = new VisualBasicValue<string>("var");
             var values = new VisualBasicValue<IEnumerable<char>>("var");
@@ -96,6 +96,23 @@ Iterate ArrayList
                 Variables = { new Variable<string>("var") },
                 Activities = { new ForEach<char> { Values = new InArgument<IEnumerable<char>>(values) }, new WriteLine { Text = new InArgument<string>(text) } }
             }};
+            ActivityXamlServices.Compile(root, new());
+            ((LambdaExpression)text.GetExpressionTree()).ReturnType.ShouldBe(typeof(string));
+            ((LambdaExpression)values.GetExpressionTree()).ReturnType.ShouldBe(typeof(IEnumerable<char>));
+        }
+        [Fact]
+        public void CSSameTextDifferentTypes()
+        {
+            var text = new CSharpValue<string>("var");
+            var values = new CSharpValue<IEnumerable<char>>("var");
+            var root = new DynamicActivity
+            {
+                Implementation = () => new Sequence
+                {
+                    Variables = { new Variable<string>("var") },
+                    Activities = { new ForEach<char> { Values = new InArgument<IEnumerable<char>>(values) }, new WriteLine { Text = new InArgument<string>(text) } }
+                }
+            };
             ActivityXamlServices.Compile(root, new());
             ((LambdaExpression)text.GetExpressionTree()).ReturnType.ShouldBe(typeof(string));
             ((LambdaExpression)values.GetExpressionTree()).ReturnType.ShouldBe(typeof(IEnumerable<char>));

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpReference.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpReference.cs
@@ -3,13 +3,16 @@
 
 using System;
 using System.Activities;
+using System.Activities.ExpressionParser;
 using System.Activities.Expressions;
 using System.Activities.Internals;
+using System.Activities.Runtime;
 using System.Activities.Validation;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Windows.Markup;
+using ActivityContext = System.Activities.ActivityContext;
 
 namespace Microsoft.CSharp.Activities;
 
@@ -18,6 +21,8 @@ namespace Microsoft.CSharp.Activities;
 public class CSharpReference<TResult> : TextExpressionBase<Location<TResult>>, ITextExpression
 {
     private CompiledExpressionInvoker _invoker;
+    private LocationFactory<TResult> _locationFactory;
+    private Expression<Func<ActivityContext, TResult>> _expressionTree;
 
     public CSharpReference() => UseOldFastPath = true;
 
@@ -28,13 +33,92 @@ public class CSharpReference<TResult> : TextExpressionBase<Location<TResult>>, I
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public override string Language => CSharpHelper.Language;
 
-    public override Expression GetExpressionTree() => IsMetadataCached ? _invoker.GetExpressionTree() : throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
+    public override Expression GetExpressionTree()
+    {
+        if (IsMetadataCached)
+        {
+            if (_expressionTree == null)
+            {
+                if (_invoker != null)
+                {
+                    return _invoker.GetExpressionTree();
+                }
+                // it's safe to create this CodeActivityMetadata here,
+                // because we know we are using it only as lookup purpose.
+                var metadata = new CodeActivityMetadata(this, GetParentEnvironment(), false);
+                var publicAccessor = CodeActivityPublicEnvironmentAccessor.CreateWithoutArgument(metadata);
+                try
+                {
+                    _expressionTree = CompileLocationExpression(publicAccessor, out var validationError);
+                    if (validationError != null)
+                    {
+                        throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ExpressionTamperedSinceLastCompiled(validationError)));
+                    }
+                }
+                finally
+                {
+                    metadata.Dispose();
+                }
+            }
+            Fx.Assert(_expressionTree.NodeType == ExpressionType.Lambda, "Lambda expression required");
+            return ExpressionUtilities.RewriteNonCompiledExpressionTree(_expressionTree);
+        }
+        throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
+    }
+
+    protected override Location<TResult> Execute(CodeActivityContext context)
+    {
+        if (_expressionTree == null)
+        {
+            return (Location<TResult>)_invoker.InvokeExpression(context);
+        }
+        _locationFactory ??= ExpressionUtilities.CreateLocationFactory<TResult>(_expressionTree);
+        return _locationFactory.CreateLocation(context);
+    }
 
     protected override void CacheMetadata(CodeActivityMetadata metadata)
     {
+        _expressionTree = null;
         _invoker = new CompiledExpressionInvoker(this, true, metadata);
-        QueueForValidation<TResult>(metadata, true);
+
+        if (QueueForValidation<TResult>(metadata, true))
+        {
+            return;
+        }
+        // If ICER is not implemented that means we haven't been compiled
+        var publicAccessor = CodeActivityPublicEnvironmentAccessor.Create(metadata);
+        _expressionTree = CompileLocationExpression(publicAccessor, out var validationError);
+        if (validationError != null)
+        {
+            metadata.AddValidationError(validationError);
+        }
     }
 
-    protected override Location<TResult> Execute(CodeActivityContext context) => (Location<TResult>)_invoker.InvokeExpression(context);
+    private Expression<Func<ActivityContext, TResult>> CompileLocationExpression(CodeActivityPublicEnvironmentAccessor publicAccessor, out string validationError)
+    {
+        Expression<Func<ActivityContext, TResult>> expressionTreeToReturn = null;
+        validationError = null;
+        try
+        {
+            expressionTreeToReturn = CSharpHelper.Compile<TResult>(ExpressionText, publicAccessor, true);
+            // inspect the expressionTree to see if it is a valid location expression(L-value)
+            string extraErrorMessage = null;
+            if (!publicAccessor.ActivityMetadata.HasViolations && (expressionTreeToReturn == null ||
+                !ExpressionUtilities.IsLocation(expressionTreeToReturn, typeof(TResult), out extraErrorMessage)))
+            {
+                var errorMessage = SR.InvalidLValueExpression;
+                if (extraErrorMessage != null)
+                {
+                    errorMessage += ":" + extraErrorMessage;
+                }
+                expressionTreeToReturn = null;
+                validationError = SR.CompilerErrorSpecificExpression(ExpressionText, errorMessage);
+            }
+        }
+        catch (SourceExpressionException e)
+        {
+            validationError = e.Message;
+        }
+        return expressionTreeToReturn;
+    }
 }

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpValue.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpValue.cs
@@ -1,15 +1,19 @@
 ﻿// This file is part of Core WF which is licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualBasic.Activities;
 using System;
 using System.Activities;
+using System.Activities.ExpressionParser;
 using System.Activities.Expressions;
 using System.Activities.Internals;
+using System.Activities.Runtime;
 using System.Activities.Validation;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Windows.Markup;
+using ActivityContext = System.Activities.ActivityContext;
 
 namespace Microsoft.CSharp.Activities;
 
@@ -18,6 +22,8 @@ namespace Microsoft.CSharp.Activities;
 public class CSharpValue<TResult> : TextExpressionBase<TResult>
 {
     private CompiledExpressionInvoker _invoker;
+    private Func<ActivityContext, TResult> _compiledExpression;
+    private Expression<Func<ActivityContext, TResult>> _expressionTree;
 
     public CSharpValue() => UseOldFastPath = true;
 
@@ -28,13 +34,67 @@ public class CSharpValue<TResult> : TextExpressionBase<TResult>
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public override string Language => CSharpHelper.Language;
 
-    public override Expression GetExpressionTree() => IsMetadataCached ? _invoker.GetExpressionTree() : throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
+    public override Expression GetExpressionTree()
+    {
+        if (!IsMetadataCached)
+        {
+            throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
+        }
+        if (_expressionTree == null)
+        {
+            if (_invoker != null)
+            {
+                return _invoker.GetExpressionTree();
+            }
+            // it's safe to create this CodeActivityMetadata here,
+            // because we know we are using it only as lookup purpose.
+            var metadata = new CodeActivityMetadata(this, GetParentEnvironment(), false);
+            var publicAccessor = CodeActivityPublicEnvironmentAccessor.CreateWithoutArgument(metadata);
+            try
+            {
+                _expressionTree = CSharpHelper.Compile<TResult>(ExpressionText, publicAccessor, false);
+            }
+            catch (SourceExpressionException e)
+            {
+                throw FxTrace.Exception.AsError(
+                    new InvalidOperationException(SR.ExpressionTamperedSinceLastCompiled(e.Message)));
+            }
+            finally
+            {
+                metadata.Dispose();
+            }
+        }
+        Fx.Assert(_expressionTree.NodeType == ExpressionType.Lambda, "Lambda expression required");
+        return ExpressionUtilities.RewriteNonCompiledExpressionTree(_expressionTree);
+    }
 
     protected override void CacheMetadata(CodeActivityMetadata metadata)
     {
+        _expressionTree = null;
         _invoker = new CompiledExpressionInvoker(this, false, metadata);
-        QueueForValidation<TResult>(metadata, false);
+
+        if (QueueForValidation<TResult>(metadata, false))
+        {
+            return;
+        }
+        try
+        {
+            var publicAccessor = CodeActivityPublicEnvironmentAccessor.Create(metadata);
+            _expressionTree = CSharpHelper.Compile<TResult>(ExpressionText, publicAccessor, false);
+        }
+        catch (SourceExpressionException e)
+        {
+            metadata.AddValidationError(e.Message);
+        }
     }
 
-    protected override TResult Execute(CodeActivityContext context) => (TResult) _invoker.InvokeExpression(context);
+    protected override TResult Execute(CodeActivityContext context)
+    {
+        if (_expressionTree == null)
+        {
+            return (TResult)_invoker.InvokeExpression(context);
+        }
+        _compiledExpression ??= _expressionTree.Compile();
+        return _compiledExpression(context);
+    }
 }


### PR DESCRIPTION
To maintain parity with VB, this PR adds support to compile C# expressions on demand in `CacheMetadata` for both `CSharpValue` and `CSharpReference`.

- [x] Unit tests (Added all unit tests that had only a VB variant)