### PR TITLE
Fix validation for c# not considering variable name is case sensitive [STUD-69312]

### DIFF
--- a/src/Test/TestCases.Workflows/ExpressionTests.cs
+++ b/src/Test/TestCases.Workflows/ExpressionTests.cs
@@ -535,4 +535,35 @@ public class ExpressionTests
         var result = ActivityValidationServices.Validate(sequence, _useValidator);
         result.Errors.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void CS_IsCaseSensitive_WhenSearchingForVariable_Throws()
+    {
+        var seq = new Sequence();
+        seq.Variables.Add(new Variable<string>("ABC"));
+        seq.Activities.Add(new WriteLine { Text = new InArgument<string>(new CSharpValue<string>("abc")) });
+        var valid = ActivityValidationServices.Validate(seq, _useValidator);
+        valid.Errors.Count.ShouldBe(1);
+        valid.Errors.First().Message.ShouldBe("CS0103: The name 'abc' does not exist in the current context");
+    }
+
+    [Fact]
+    public void CS_IsCaseSensitive_WhenSearchingForVariable_Succeeds()
+    {
+        var seq = new Sequence();
+        seq.Variables.Add(new Variable<string>("ABC"));
+        seq.Activities.Add(new WriteLine { Text = new InArgument<string>(new CSharpValue<string>("ABC")) });
+        var valid = ActivityValidationServices.Validate(seq, _useValidator);
+        valid.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void VB_IsCaseInsensitive()
+    {
+        var seq = new Sequence();
+        seq.Variables.Add(new Variable<string>("ABC"));
+        seq.Activities.Add(new WriteLine { Text = new InArgument<string>(new VisualBasicValue<string>("abc")) });
+        var valid = ActivityValidationServices.Validate(seq, _useValidator);
+        valid.Errors.ShouldBeEmpty();
+    }
 }

--- a/src/Test/TestCases.Workflows/JitCompilerTests.cs
+++ b/src/Test/TestCases.Workflows/JitCompilerTests.cs
@@ -50,7 +50,7 @@ namespace TestCases.Workflows
         [Fact]
         public void VisualBasicJitCompiler_PropertyAccess_SameNameAsVariable()
         {
-            static Type VariableTypeGetter(string name)
+            static Type VariableTypeGetter(string name, StringComparison stringComparison)
             {
                 return name switch
                 {
@@ -69,7 +69,7 @@ namespace TestCases.Workflows
         [InlineData(17)]
         public void VisualBasicJitCompiler_ExpressionWithMultipleVariablesVariables(int noOfVar)
         {
-            static Type VariableTypeGetter(string name)
+            static Type VariableTypeGetter(string name, StringComparison stringComparison)
             {
                 return name switch
                 {
@@ -85,7 +85,7 @@ namespace TestCases.Workflows
         [Fact]
         public void CSharpJitCompiler_PropertyAccess()
         {
-            static Type VariableTypeGetter(string name)
+            static Type VariableTypeGetter(string name, StringComparison stringComparison)
             {
                 return name switch
                 {
@@ -108,7 +108,7 @@ namespace TestCases.Workflows
         [InlineData(17)]
         public void CSharpJitCompiler_ExpressionWithMultipleVariablesVariables(int noOfVar)
         {
-            static Type VariableTypeGetter(string name)
+            static Type VariableTypeGetter(string name, StringComparison stringComparison)
             {
                 return name switch
                 {
@@ -125,7 +125,7 @@ namespace TestCases.Workflows
         public void VbExpression_UndeclaredObject()
         {
             var expressionToCompile = "new UndeclaredClass()";
-            var sut = () => _vbJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, (s)=>null, typeof(object)));
+            var sut = () => _vbJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, (s, c)=>null, typeof(object)));
 
             Assert.ThrowsAny<SourceExpressionException>(sut);
         }
@@ -134,7 +134,7 @@ namespace TestCases.Workflows
         public void VbExpression_WithObjectInitializer()
         {
             var expressionToCompile = "new TestIndexerClass() With {.Field=\"1\"}";
-            var result = _vbJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, (s)=>null, typeof(TestIndexerClass)));
+            var result = _vbJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, (s, c)=>null, typeof(TestIndexerClass)));
             result.ReturnType.ShouldBe(typeof(TestIndexerClass));
         }
 
@@ -142,11 +142,11 @@ namespace TestCases.Workflows
         public void VbExpression_UndeclaredObjectWithObjectInitializer()
         {
             var expressionToCompile = "new UndeclaredClass() With {.Field=\"1\"}";
-            var sut = () => _vbJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, (s)=>null, typeof(object)));
+            var sut = () => _vbJitCompiler.CompileExpression(new ExpressionToCompile(expressionToCompile, _namespaces, (s, c)=>null, typeof(object)));
 
             Assert.ThrowsAny<SourceExpressionException>(sut);
         }
-        private static Type VariableTypeGetter(string name)
+        private static Type VariableTypeGetter(string name, StringComparison stringComparison)
             => name switch
             {
                 "testIndexerClass" => typeof(TestIndexerClass),

--- a/src/Test/TestCases.Workflows/XamlTests.cs
+++ b/src/Test/TestCases.Workflows/XamlTests.cs
@@ -317,8 +317,8 @@ namespace TestCases.Workflows
         public void Should_compile_CSharp()
         {
             var compiler = new CSharpJitCompiler(new[] { typeof(Expression).Assembly, typeof(Enumerable).Assembly }.ToHashSet());
-            var result = compiler.CompileExpression(new ExpressionToCompile("source.Select(s=>s).Sum()", new[] { "System", "System.Linq", "System.Linq.Expressions", "System.Collections.Generic" },
-                name => name == "source" ? typeof(List<int>) : null, typeof(int)));
+            var result = compiler.CompileExpression(new ExpressionToCompile("source.Select(s=>s).Sum()", ["System", "System.Linq", "System.Linq.Expressions", "System.Collections.Generic"],
+                (name, comparer )=> name == "source" ? typeof(List<int>) : null, typeof(int)));
             ((Func<List<int>, int>)result.Compile())(new List<int> { 1, 2, 3 }).ShouldBe(6);
         }
 
@@ -326,7 +326,7 @@ namespace TestCases.Workflows
         public void Should_Fail_VBConversion()
         {
             var compiler = new VbJitCompiler(new[] { typeof(int).Assembly, typeof(Expression).Assembly, typeof(Conversions).Assembly }.ToHashSet());
-            new Action(() => compiler.CompileExpression(new ExpressionToCompile("1", new[] { "System", "System.Linq", "System.Linq.Expressions" }, _ => typeof(int), typeof(string))))
+            new Action(() => compiler.CompileExpression(new ExpressionToCompile("1", new[] { "System", "System.Linq", "System.Linq.Expressions" }, (_, __) => typeof(int), typeof(string))))
                 .ShouldThrow<SourceExpressionException>().Message.ShouldContain("BC30512: Option Strict On disallows implicit conversions");
         }
 
@@ -391,6 +391,7 @@ namespace TestCases.Workflows
                 </Activity>";
         [Fact]
         public void CompileExpressionsDefault() => InvokeWorkflow(CSharpExpressions);
+
         [Fact]
         public void CompileExpressionsWithCompiler() =>
             new Action(() => ActivityXamlServices.Load(new StringReader(CSharpExpressions),
@@ -414,6 +415,7 @@ namespace TestCases.Workflows
             new Action(() => InvokeWorkflow(xaml)).ShouldThrow<InvalidOperationException>().Data.Values.Cast<string>()
                 .ShouldAllBe(error => error.Contains("error CS0103: The name 'constant' does not exist in the current context"));
         }
+
         [Fact]
         public void SetCompiledExpressionRootForImplementation()
         {
@@ -421,6 +423,7 @@ namespace TestCases.Workflows
             CompiledExpressionInvoker.SetCompiledExpressionRootForImplementation(writeLine, new Expressions());
             WorkflowInvoker.Invoke(writeLine);
         }
+
         [Fact]
         public void ValidateSkipCompilation()
         {
@@ -428,6 +431,7 @@ namespace TestCases.Workflows
             var results = ActivityValidationServices.Validate(writeLine, new() { SkipExpressionCompilation = true });
             results.Errors.ShouldBeEmpty();
         }
+
         [Fact]
         public void DuplicateVariable()
         {
@@ -439,6 +443,7 @@ xmlns:hw='clr-namespace:TestCases.Workflows;assembly=TestCases.Workflows'>
             var withMyVar = (WithMyVar)WorkflowInspectionServices.Resolve(root, "1.1");
             ((ITextExpression)((Sequence)withMyVar.Body.Handler).Activities[0]).GetExpressionTree();
         }
+
         [Fact]
         public void CSharpInputOutput()
         {

--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -29,7 +29,7 @@ public abstract class JustInTimeCompiler
 public record CompilerInput(string Code, IReadOnlyCollection<string> ImportedNamespaces) { }
 
 public record ExpressionToCompile(string Code, IReadOnlyCollection<string> ImportedNamespaces,
-    Func<string, Type> VariableTypeGetter, Type LambdaReturnType)
+    Func<string, StringComparison, Type> VariableTypeGetter, Type LambdaReturnType)
     : CompilerInput(Code, ImportedNamespaces)
 { }
 
@@ -57,7 +57,7 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
         var identifiers = GetIdentifiers(syntaxTree);
         var resolvedIdentifiers =
             identifiers
-                .Select(name => (Name: name, Type: expressionToCompile.VariableTypeGetter(name)))
+                .Select(name => (Name: name, Type: expressionToCompile.VariableTypeGetter(name, CompilerHelper.IdentifierNameComparison)))
                 .Where(var => var.Type != null)
                 .ToArray();
         var names = string.Join(CompilerHelper.Comma, resolvedIdentifiers.Select(var => var.Name));

--- a/src/UiPath.Workflow/Activities/Utils/CSharpCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CSharpCompilerHelper.cs
@@ -23,6 +23,8 @@ namespace System.Activities
 
         public override StringComparer IdentifierNameComparer { get; } = StringComparer.Ordinal;
 
+        public override StringComparison IdentifierNameComparison { get; } = StringComparison.Ordinal;
+
         public override string GetTypeName(Type type) =>
             (string)s_typeNameFormatter.FormatTypeName(type, s_typeOptions);
 

--- a/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
@@ -17,6 +17,8 @@ namespace System.Activities
 
         public abstract StringComparer IdentifierNameComparer { get; }
 
+        public abstract StringComparison IdentifierNameComparison { get; }
+
         public abstract int IdentifierKind { get; }
 
         public abstract (string, string) DefineDelegate(string types);

--- a/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
@@ -17,6 +17,8 @@ namespace System.Activities
 
         public override StringComparer IdentifierNameComparer { get; } = StringComparer.OrdinalIgnoreCase;
 
+        public override StringComparison IdentifierNameComparison { get; } = StringComparison.OrdinalIgnoreCase;
+
         public override VisualBasicParseOptions ScriptParseOptions { get; } = new VisualBasicParseOptions(kind: SourceCodeKind.Script, languageVersion: LanguageVersion.Latest);
 
 

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpDesignerHelper.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpDesignerHelper.cs
@@ -14,11 +14,13 @@ namespace Microsoft.CSharp.Activities;
 
 internal class CSharpHelper : JitCompilerHelper<CSharpHelper>
 {
+    protected override StringComparison StringComparison => StringComparison.Ordinal;
+
+    protected override JustInTimeCompiler CreateCompiler(HashSet<Assembly> references) =>
+        new CSharpJitCompiler(references);
+
     public CSharpHelper(string expressionText, HashSet<AssemblyReference> assemblyReferences,
         HashSet<string> namespaceImportsNames) : base(expressionText, assemblyReferences, namespaceImportsNames) { }
-
-    protected override JustInTimeCompiler CreateCompiler(HashSet<Assembly> references) => 
-        new CSharpJitCompiler(references);
 
     internal const string Language = "C#";
 }

--- a/src/UiPath.Workflow/Microsoft/CSharp/CSharpExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/CSharpExpressionCompiler.cs
@@ -43,7 +43,7 @@ internal sealed class CSharpExpressionCompiler : ExpressionCompiler
         var identifiers = syntaxTree.GetRoot().DescendantNodesAndSelf().Where(n => n.RawKind == (int)SyntaxKind.IdentifierName)
                                     .Select(n => n.ToString()).Distinct(_compilerHelper.IdentifierNameComparer);
         var resolvedIdentifiers = identifiers
-                .Select(name => (Name: name, Type: new ScriptAndTypeScope(environment).FindVariable(name)))
+                .Select(name => (Name: name, Type: new ScriptAndTypeScope(environment).FindVariable(name, _compilerHelper.IdentifierNameComparison)))
                 .Where(var => var.Type != null)
                 .ToArray();
 

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicDesignerHelper.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicDesignerHelper.cs
@@ -14,6 +14,8 @@ namespace Microsoft.VisualBasic.Activities;
 
 internal class VisualBasicHelper : JitCompilerHelper<VisualBasicHelper>
 {
+    protected override StringComparison StringComparison => StringComparison.OrdinalIgnoreCase;
+
     public VisualBasicHelper(string expressionText, HashSet<AssemblyReference> assemblyReferences,
         HashSet<string> namespaceImportsNames) : base(expressionText, assemblyReferences, namespaceImportsNames) { }
 

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
@@ -45,7 +45,7 @@ internal sealed class VisualBasicExpressionCompiler : ExpressionCompiler
         var identifiers = syntaxTree.GetRoot().DescendantNodesAndSelf().Where(n => n.RawKind == (int)SyntaxKind.IdentifierName)
                                     .Select(n => n.ToString()).Distinct(_compilerHelper.IdentifierNameComparer);
         var resolvedIdentifiers = identifiers
-                .Select(name => (Name: name, Type: new ScriptAndTypeScope(environment).FindVariable(name)))
+                .Select(name => (Name: name, Type: new ScriptAndTypeScope(environment).FindVariable(name, _compilerHelper.IdentifierNameComparison)))
                 .Where(var => var.Type != null)
                 .ToArray();
 

--- a/src/UiPath.Workflow/Validation/RoslynExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/RoslynExpressionValidator.cs
@@ -241,7 +241,7 @@ public abstract class RoslynExpressionValidator
                                     .Select(n => n.ToString()).Distinct(CompilerHelper.IdentifierNameComparer);
         var resolvedIdentifiers =
             identifiers
-                .Select(name => (Name: name, Type: new ScriptAndTypeScope(expressionToValidate.Environment).FindVariable(name)))
+                .Select(name => (Name: name, Type: new ScriptAndTypeScope(expressionToValidate.Environment).FindVariable(name, CompilerHelper.IdentifierNameComparison)))
                 .Where(var => var.Type != null)
                 .ToArray();
 


### PR DESCRIPTION
The default behavior was the VB one, checking for variable names was done with StringComparison.OrdinalIgnoreCase
https://uipath.atlassian.net/browse/STUD-69312