### PR TITLE
Parse expressions from an activity implementation property

### DIFF
--- a/src/Test/TestCases.Workflows/ExpressionCompilerResults/CS_ExpressionCompilerResult
+++ b/src/Test/TestCases.Workflows/ExpressionCompilerResults/CS_ExpressionCompilerResult
@@ -1,0 +1,755 @@
+namespace TestNamespace {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Activities;
+    using System.Activities.Expressions;
+    using System.Activities.Statements;
+    using System.Activities.XamlIntegration;
+    
+    
+    public class TestClass : System.Activities.XamlIntegration.ICompiledExpressionRoot {
+        
+        private System.Activities.Activity rootActivity;
+        
+        private object dataContextActivities;
+        
+        private bool forImplementation = true;
+        
+        public TestClass(System.Activities.Activity rootActivity) {
+            if ((rootActivity == null)) {
+                throw new System.ArgumentNullException("rootActivity");
+            }
+            this.rootActivity = rootActivity;
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public string GetLanguage() {
+            return "C#";
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public object InvokeExpression(int expressionId, System.Collections.Generic.IList<System.Activities.LocationReference> locations, System.Activities.ActivityContext activityContext) {
+            if ((this.dataContextActivities == null)) {
+                this.dataContextActivities = TestClass_TypedDataContext2_ForReadOnly.GetDataContextActivitiesHelper(this.rootActivity, this.forImplementation);
+            }
+            if ((expressionId == 0)) {
+                System.Activities.XamlIntegration.CompiledDataContext[] cachedCompiledDataContext = TestClass_TypedDataContext2_ForReadOnly.GetCompiledDataContextCacheHelper(this.dataContextActivities, activityContext, this.rootActivity, this.forImplementation, 4);
+                if ((cachedCompiledDataContext[0] == null)) {
+                    cachedCompiledDataContext[0] = new TestClass_TypedDataContext2_ForReadOnly(locations, activityContext, true);
+                }
+                TestClass_TypedDataContext2_ForReadOnly valDataContext0 = ((TestClass_TypedDataContext2_ForReadOnly)(cachedCompiledDataContext[0]));
+                return valDataContext0.ValueType___Expr0Get();
+            }
+            if ((expressionId == 1)) {
+                System.Activities.XamlIntegration.CompiledDataContext[] cachedCompiledDataContext = TestClass_TypedDataContext2.GetCompiledDataContextCacheHelper(this.dataContextActivities, activityContext, this.rootActivity, this.forImplementation, 4);
+                if ((cachedCompiledDataContext[1] == null)) {
+                    cachedCompiledDataContext[1] = new TestClass_TypedDataContext2(locations, activityContext, true);
+                }
+                TestClass_TypedDataContext2 refDataContext1 = ((TestClass_TypedDataContext2)(cachedCompiledDataContext[1]));
+                return refDataContext1.GetLocation<string>(refDataContext1.ValueType___Expr1Get, refDataContext1.ValueType___Expr1Set, expressionId, this.rootActivity, activityContext);
+            }
+            if ((expressionId == 2)) {
+                System.Activities.XamlIntegration.CompiledDataContext[] cachedCompiledDataContext = TestClass_TypedDataContext2_ForReadOnly.GetCompiledDataContextCacheHelper(this.dataContextActivities, activityContext, this.rootActivity, this.forImplementation, 4);
+                if ((cachedCompiledDataContext[0] == null)) {
+                    cachedCompiledDataContext[0] = new TestClass_TypedDataContext2_ForReadOnly(locations, activityContext, true);
+                }
+                TestClass_TypedDataContext2_ForReadOnly valDataContext2 = ((TestClass_TypedDataContext2_ForReadOnly)(cachedCompiledDataContext[0]));
+                return valDataContext2.ValueType___Expr2Get();
+            }
+            if ((expressionId == 3)) {
+                System.Activities.XamlIntegration.CompiledDataContext[] cachedCompiledDataContext = TestClass_TypedDataContext3.GetCompiledDataContextCacheHelper(this.dataContextActivities, activityContext, this.rootActivity, this.forImplementation, 4);
+                if ((cachedCompiledDataContext[2] == null)) {
+                    cachedCompiledDataContext[2] = new TestClass_TypedDataContext3(locations, activityContext, true);
+                }
+                TestClass_TypedDataContext3 refDataContext3 = ((TestClass_TypedDataContext3)(cachedCompiledDataContext[2]));
+                return refDataContext3.GetLocation<string>(refDataContext3.ValueType___Expr3Get, refDataContext3.ValueType___Expr3Set, expressionId, this.rootActivity, activityContext);
+            }
+            if ((expressionId == 4)) {
+                System.Activities.XamlIntegration.CompiledDataContext[] cachedCompiledDataContext = TestClass_TypedDataContext3_ForReadOnly.GetCompiledDataContextCacheHelper(this.dataContextActivities, activityContext, this.rootActivity, this.forImplementation, 4);
+                if ((cachedCompiledDataContext[3] == null)) {
+                    cachedCompiledDataContext[3] = new TestClass_TypedDataContext3_ForReadOnly(locations, activityContext, true);
+                }
+                TestClass_TypedDataContext3_ForReadOnly valDataContext4 = ((TestClass_TypedDataContext3_ForReadOnly)(cachedCompiledDataContext[3]));
+                return valDataContext4.ValueType___Expr4Get();
+            }
+            if ((expressionId == 5)) {
+                System.Activities.XamlIntegration.CompiledDataContext[] cachedCompiledDataContext = TestClass_TypedDataContext2_ForReadOnly.GetCompiledDataContextCacheHelper(this.dataContextActivities, activityContext, this.rootActivity, this.forImplementation, 4);
+                if ((cachedCompiledDataContext[0] == null)) {
+                    cachedCompiledDataContext[0] = new TestClass_TypedDataContext2_ForReadOnly(locations, activityContext, true);
+                }
+                TestClass_TypedDataContext2_ForReadOnly valDataContext5 = ((TestClass_TypedDataContext2_ForReadOnly)(cachedCompiledDataContext[0]));
+                return valDataContext5.ValueType___Expr5Get();
+            }
+            return null;
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public object InvokeExpression(int expressionId, System.Collections.Generic.IList<System.Activities.Location> locations) {
+            if ((expressionId == 0)) {
+                TestClass_TypedDataContext2_ForReadOnly valDataContext0 = new TestClass_TypedDataContext2_ForReadOnly(locations, true);
+                return valDataContext0.ValueType___Expr0Get();
+            }
+            if ((expressionId == 1)) {
+                TestClass_TypedDataContext2 refDataContext1 = new TestClass_TypedDataContext2(locations, true);
+                return refDataContext1.GetLocation<string>(refDataContext1.ValueType___Expr1Get, refDataContext1.ValueType___Expr1Set);
+            }
+            if ((expressionId == 2)) {
+                TestClass_TypedDataContext2_ForReadOnly valDataContext2 = new TestClass_TypedDataContext2_ForReadOnly(locations, true);
+                return valDataContext2.ValueType___Expr2Get();
+            }
+            if ((expressionId == 3)) {
+                TestClass_TypedDataContext3 refDataContext3 = new TestClass_TypedDataContext3(locations, true);
+                return refDataContext3.GetLocation<string>(refDataContext3.ValueType___Expr3Get, refDataContext3.ValueType___Expr3Set);
+            }
+            if ((expressionId == 4)) {
+                TestClass_TypedDataContext3_ForReadOnly valDataContext4 = new TestClass_TypedDataContext3_ForReadOnly(locations, true);
+                return valDataContext4.ValueType___Expr4Get();
+            }
+            if ((expressionId == 5)) {
+                TestClass_TypedDataContext2_ForReadOnly valDataContext5 = new TestClass_TypedDataContext2_ForReadOnly(locations, true);
+                return valDataContext5.ValueType___Expr5Get();
+            }
+            return null;
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool CanExecuteExpression(System.Type type, string expressionText, bool isReference, System.Collections.Generic.IList<System.Activities.LocationReference> locations, out int expressionId) {
+            if ((((isReference == false) 
+                        && (type == typeof(string))) 
+                        && ((expressionText == "var1") 
+                        && (TestClass_TypedDataContext2_ForReadOnly.Validate(locations, true, 0) == true)))) {
+                expressionId = 0;
+                return true;
+            }
+            if ((((isReference == true) 
+                        && (type == typeof(string))) 
+                        && ((expressionText == "var1") 
+                        && (TestClass_TypedDataContext2.Validate(locations, true, 0) == true)))) {
+                expressionId = 1;
+                return true;
+            }
+            if ((((isReference == false) 
+                        && (type == typeof(bool))) 
+                        && ((expressionText == "var1 != \"test\"") 
+                        && (TestClass_TypedDataContext2_ForReadOnly.Validate(locations, true, 0) == true)))) {
+                expressionId = 2;
+                return true;
+            }
+            if ((((isReference == true) 
+                        && (type == typeof(string))) 
+                        && ((expressionText == "var2") 
+                        && (TestClass_TypedDataContext3.Validate(locations, true, 0) == true)))) {
+                expressionId = 3;
+                return true;
+            }
+            if ((((isReference == false) 
+                        && (type == typeof(string))) 
+                        && ((expressionText == "var2") 
+                        && (TestClass_TypedDataContext3_ForReadOnly.Validate(locations, true, 0) == true)))) {
+                expressionId = 4;
+                return true;
+            }
+            if ((((isReference == false) 
+                        && (type == typeof(string))) 
+                        && ((expressionText == "test3") 
+                        && (TestClass_TypedDataContext2_ForReadOnly.Validate(locations, true, 0) == true)))) {
+                expressionId = 5;
+                return true;
+            }
+            expressionId = -1;
+            return false;
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool CanExecuteExpression(string expressionText, bool isReference, System.Collections.Generic.IList<System.Activities.LocationReference> locations, out int expressionId) {
+            throw new System.NotImplementedException();
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public System.Collections.Generic.IList<string> GetRequiredLocations(int expressionId) {
+            return null;
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public System.Linq.Expressions.Expression GetExpressionTreeForExpression(int expressionId, System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences) {
+            if ((expressionId == 0)) {
+                return new TestClass_TypedDataContext2_ForReadOnly(locationReferences).@__Expr0GetTree();
+            }
+            if ((expressionId == 1)) {
+                return new TestClass_TypedDataContext2(locationReferences).@__Expr1GetTree();
+            }
+            if ((expressionId == 2)) {
+                return new TestClass_TypedDataContext2_ForReadOnly(locationReferences).@__Expr2GetTree();
+            }
+            if ((expressionId == 3)) {
+                return new TestClass_TypedDataContext3(locationReferences).@__Expr3GetTree();
+            }
+            if ((expressionId == 4)) {
+                return new TestClass_TypedDataContext3_ForReadOnly(locationReferences).@__Expr4GetTree();
+            }
+            if ((expressionId == 5)) {
+                return new TestClass_TypedDataContext2_ForReadOnly(locationReferences).@__Expr5GetTree();
+            }
+            return null;
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        private class TestClass_TypedDataContext0 : System.Activities.XamlIntegration.CompiledDataContext {
+            
+            private int locationsOffset;
+            
+            private static int expectedLocationsCount;
+            
+            public TestClass_TypedDataContext0(System.Collections.Generic.IList<System.Activities.LocationReference> locations, System.Activities.ActivityContext activityContext, bool computelocationsOffset) : 
+                    base(locations, activityContext) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext0(System.Collections.Generic.IList<System.Activities.Location> locations, bool computelocationsOffset) : 
+                    base(locations) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext0(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences) : 
+                    base(locationReferences) {
+            }
+            
+            internal static object GetDataContextActivitiesHelper(System.Activities.Activity compiledRoot, bool forImplementation) {
+                return System.Activities.XamlIntegration.CompiledDataContext.GetDataContextActivities(compiledRoot, forImplementation);
+            }
+            
+            internal static System.Activities.XamlIntegration.CompiledDataContext[] GetCompiledDataContextCacheHelper(object dataContextActivities, System.Activities.ActivityContext activityContext, System.Activities.Activity compiledRoot, bool forImplementation, int compiledDataContextCount) {
+                return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount);
+            }
+            
+            public virtual void SetLocationsOffset(int locationsOffsetValue) {
+                locationsOffset = locationsOffsetValue;
+            }
+            
+            public static bool Validate(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences, bool validateLocationCount, int offset) {
+                if (((validateLocationCount == true) 
+                            && (locationReferences.Count < 0))) {
+                    return false;
+                }
+                expectedLocationsCount = 0;
+                return true;
+            }
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        private class TestClass_TypedDataContext0_ForReadOnly : System.Activities.XamlIntegration.CompiledDataContext {
+            
+            private int locationsOffset;
+            
+            private static int expectedLocationsCount;
+            
+            public TestClass_TypedDataContext0_ForReadOnly(System.Collections.Generic.IList<System.Activities.LocationReference> locations, System.Activities.ActivityContext activityContext, bool computelocationsOffset) : 
+                    base(locations, activityContext) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext0_ForReadOnly(System.Collections.Generic.IList<System.Activities.Location> locations, bool computelocationsOffset) : 
+                    base(locations) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext0_ForReadOnly(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences) : 
+                    base(locationReferences) {
+            }
+            
+            internal static object GetDataContextActivitiesHelper(System.Activities.Activity compiledRoot, bool forImplementation) {
+                return System.Activities.XamlIntegration.CompiledDataContext.GetDataContextActivities(compiledRoot, forImplementation);
+            }
+            
+            internal static System.Activities.XamlIntegration.CompiledDataContext[] GetCompiledDataContextCacheHelper(object dataContextActivities, System.Activities.ActivityContext activityContext, System.Activities.Activity compiledRoot, bool forImplementation, int compiledDataContextCount) {
+                return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount);
+            }
+            
+            public virtual void SetLocationsOffset(int locationsOffsetValue) {
+                locationsOffset = locationsOffsetValue;
+            }
+            
+            public static bool Validate(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences, bool validateLocationCount, int offset) {
+                if (((validateLocationCount == true) 
+                            && (locationReferences.Count < 0))) {
+                    return false;
+                }
+                expectedLocationsCount = 0;
+                return true;
+            }
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        private class TestClass_TypedDataContext1 : TestClass_TypedDataContext0 {
+            
+            private int locationsOffset;
+            
+            private static int expectedLocationsCount;
+            
+            public TestClass_TypedDataContext1(System.Collections.Generic.IList<System.Activities.LocationReference> locations, System.Activities.ActivityContext activityContext, bool computelocationsOffset) : 
+                    base(locations, activityContext, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext1(System.Collections.Generic.IList<System.Activities.Location> locations, bool computelocationsOffset) : 
+                    base(locations, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext1(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences) : 
+                    base(locationReferences) {
+            }
+            
+            internal new static System.Activities.XamlIntegration.CompiledDataContext[] GetCompiledDataContextCacheHelper(object dataContextActivities, System.Activities.ActivityContext activityContext, System.Activities.Activity compiledRoot, bool forImplementation, int compiledDataContextCount) {
+                return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount);
+            }
+            
+            public new virtual void SetLocationsOffset(int locationsOffsetValue) {
+                locationsOffset = locationsOffsetValue;
+                base.SetLocationsOffset(locationsOffset);
+            }
+            
+            public new static bool Validate(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences, bool validateLocationCount, int offset) {
+                if (((validateLocationCount == true) 
+                            && (locationReferences.Count < 0))) {
+                    return false;
+                }
+                expectedLocationsCount = 0;
+                return TestClass_TypedDataContext0.Validate(locationReferences, false, offset);
+            }
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        private class TestClass_TypedDataContext1_ForReadOnly : TestClass_TypedDataContext0_ForReadOnly {
+            
+            private int locationsOffset;
+            
+            private static int expectedLocationsCount;
+            
+            public TestClass_TypedDataContext1_ForReadOnly(System.Collections.Generic.IList<System.Activities.LocationReference> locations, System.Activities.ActivityContext activityContext, bool computelocationsOffset) : 
+                    base(locations, activityContext, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext1_ForReadOnly(System.Collections.Generic.IList<System.Activities.Location> locations, bool computelocationsOffset) : 
+                    base(locations, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext1_ForReadOnly(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences) : 
+                    base(locationReferences) {
+            }
+            
+            internal new static System.Activities.XamlIntegration.CompiledDataContext[] GetCompiledDataContextCacheHelper(object dataContextActivities, System.Activities.ActivityContext activityContext, System.Activities.Activity compiledRoot, bool forImplementation, int compiledDataContextCount) {
+                return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount);
+            }
+            
+            public new virtual void SetLocationsOffset(int locationsOffsetValue) {
+                locationsOffset = locationsOffsetValue;
+                base.SetLocationsOffset(locationsOffset);
+            }
+            
+            public new static bool Validate(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences, bool validateLocationCount, int offset) {
+                if (((validateLocationCount == true) 
+                            && (locationReferences.Count < 0))) {
+                    return false;
+                }
+                expectedLocationsCount = 0;
+                return TestClass_TypedDataContext0_ForReadOnly.Validate(locationReferences, false, offset);
+            }
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        private class TestClass_TypedDataContext2 : TestClass_TypedDataContext1 {
+            
+            private int locationsOffset;
+            
+            private static int expectedLocationsCount;
+            
+            public TestClass_TypedDataContext2(System.Collections.Generic.IList<System.Activities.LocationReference> locations, System.Activities.ActivityContext activityContext, bool computelocationsOffset) : 
+                    base(locations, activityContext, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext2(System.Collections.Generic.IList<System.Activities.Location> locations, bool computelocationsOffset) : 
+                    base(locations, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext2(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences) : 
+                    base(locationReferences) {
+            }
+            
+            protected string var1 {
+                get {
+                    return ((string)(this.GetVariableValue((0 + locationsOffset))));
+                }
+                set {
+                    this.SetVariableValue((0 + locationsOffset), value);
+                }
+            }
+            
+            internal new static System.Activities.XamlIntegration.CompiledDataContext[] GetCompiledDataContextCacheHelper(object dataContextActivities, System.Activities.ActivityContext activityContext, System.Activities.Activity compiledRoot, bool forImplementation, int compiledDataContextCount) {
+                return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount);
+            }
+            
+            public new virtual void SetLocationsOffset(int locationsOffsetValue) {
+                locationsOffset = locationsOffsetValue;
+                base.SetLocationsOffset(locationsOffset);
+            }
+            
+            internal System.Linq.Expressions.Expression @__Expr1GetTree() {
+                System.Linq.Expressions.Expression<System.Func<string>> expression = () => var1;
+                return base.RewriteExpressionTree(expression);
+            }
+            
+            [System.Diagnostics.DebuggerHiddenAttribute()]
+            public string @__Expr1Get() {
+                return var1;
+            }
+            
+            public string ValueType___Expr1Get() {
+                this.GetValueTypeValues();
+                return this.@__Expr1Get();
+            }
+            
+            [System.Diagnostics.DebuggerHiddenAttribute()]
+            public void @__Expr1Set(string value) {
+                var1 = value;
+            }
+            
+            public void ValueType___Expr1Set(string value) {
+                this.GetValueTypeValues();
+                this.@__Expr1Set(value);
+                this.SetValueTypeValues();
+            }
+            
+            public new static bool Validate(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences, bool validateLocationCount, int offset) {
+                if (((validateLocationCount == true) 
+                            && (locationReferences.Count < 1))) {
+                    return false;
+                }
+                if ((validateLocationCount == true)) {
+                    offset = (locationReferences.Count - 1);
+                }
+                expectedLocationsCount = 1;
+                if (((locationReferences[(offset + 0)].Name != "var1") 
+                            || (locationReferences[(offset + 0)].Type != typeof(string)))) {
+                    return false;
+                }
+                return TestClass_TypedDataContext1.Validate(locationReferences, false, offset);
+            }
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        private class TestClass_TypedDataContext2_ForReadOnly : TestClass_TypedDataContext1_ForReadOnly {
+            
+            private int locationsOffset;
+            
+            private static int expectedLocationsCount;
+            
+            public TestClass_TypedDataContext2_ForReadOnly(System.Collections.Generic.IList<System.Activities.LocationReference> locations, System.Activities.ActivityContext activityContext, bool computelocationsOffset) : 
+                    base(locations, activityContext, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext2_ForReadOnly(System.Collections.Generic.IList<System.Activities.Location> locations, bool computelocationsOffset) : 
+                    base(locations, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext2_ForReadOnly(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences) : 
+                    base(locationReferences) {
+            }
+            
+            protected string var1 {
+                get {
+                    return ((string)(this.GetVariableValue((0 + locationsOffset))));
+                }
+            }
+            
+            internal new static System.Activities.XamlIntegration.CompiledDataContext[] GetCompiledDataContextCacheHelper(object dataContextActivities, System.Activities.ActivityContext activityContext, System.Activities.Activity compiledRoot, bool forImplementation, int compiledDataContextCount) {
+                return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount);
+            }
+            
+            public new virtual void SetLocationsOffset(int locationsOffsetValue) {
+                locationsOffset = locationsOffsetValue;
+                base.SetLocationsOffset(locationsOffset);
+            }
+            
+            internal System.Linq.Expressions.Expression @__Expr0GetTree() {
+                System.Linq.Expressions.Expression<System.Func<string>> expression = () => var1;
+                return base.RewriteExpressionTree(expression);
+            }
+            
+            [System.Diagnostics.DebuggerHiddenAttribute()]
+            public string @__Expr0Get() {
+                return var1;
+            }
+            
+            public string ValueType___Expr0Get() {
+                this.GetValueTypeValues();
+                return this.@__Expr0Get();
+            }
+            
+            internal System.Linq.Expressions.Expression @__Expr2GetTree() {
+                System.Linq.Expressions.Expression<System.Func<bool>> expression = () => var1 != "test";
+                return base.RewriteExpressionTree(expression);
+            }
+            
+            [System.Diagnostics.DebuggerHiddenAttribute()]
+            public bool @__Expr2Get() {
+                return var1 != "test";
+            }
+            
+            public bool ValueType___Expr2Get() {
+                this.GetValueTypeValues();
+                return this.@__Expr2Get();
+            }
+            
+            internal System.Linq.Expressions.Expression @__Expr5GetTree() {
+                System.Linq.Expressions.Expression<System.Func<string>> expression = () => test3;
+                return base.RewriteExpressionTree(expression);
+            }
+            
+            [System.Diagnostics.DebuggerHiddenAttribute()]
+            public string @__Expr5Get() {
+                return test3;
+            }
+            
+            public string ValueType___Expr5Get() {
+                this.GetValueTypeValues();
+                return this.@__Expr5Get();
+            }
+            
+            public new static bool Validate(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences, bool validateLocationCount, int offset) {
+                if (((validateLocationCount == true) 
+                            && (locationReferences.Count < 1))) {
+                    return false;
+                }
+                if ((validateLocationCount == true)) {
+                    offset = (locationReferences.Count - 1);
+                }
+                expectedLocationsCount = 1;
+                if (((locationReferences[(offset + 0)].Name != "var1") 
+                            || (locationReferences[(offset + 0)].Type != typeof(string)))) {
+                    return false;
+                }
+                return TestClass_TypedDataContext1_ForReadOnly.Validate(locationReferences, false, offset);
+            }
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        private class TestClass_TypedDataContext3 : TestClass_TypedDataContext2 {
+            
+            private int locationsOffset;
+            
+            private static int expectedLocationsCount;
+            
+            public TestClass_TypedDataContext3(System.Collections.Generic.IList<System.Activities.LocationReference> locations, System.Activities.ActivityContext activityContext, bool computelocationsOffset) : 
+                    base(locations, activityContext, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext3(System.Collections.Generic.IList<System.Activities.Location> locations, bool computelocationsOffset) : 
+                    base(locations, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext3(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences) : 
+                    base(locationReferences) {
+            }
+            
+            protected string var2 {
+                get {
+                    return ((string)(this.GetVariableValue((1 + locationsOffset))));
+                }
+                set {
+                    this.SetVariableValue((1 + locationsOffset), value);
+                }
+            }
+            
+            internal new static System.Activities.XamlIntegration.CompiledDataContext[] GetCompiledDataContextCacheHelper(object dataContextActivities, System.Activities.ActivityContext activityContext, System.Activities.Activity compiledRoot, bool forImplementation, int compiledDataContextCount) {
+                return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount);
+            }
+            
+            public new virtual void SetLocationsOffset(int locationsOffsetValue) {
+                locationsOffset = locationsOffsetValue;
+                base.SetLocationsOffset(locationsOffset);
+            }
+            
+            internal System.Linq.Expressions.Expression @__Expr3GetTree() {
+                System.Linq.Expressions.Expression<System.Func<string>> expression = () => var2;
+                return base.RewriteExpressionTree(expression);
+            }
+            
+            [System.Diagnostics.DebuggerHiddenAttribute()]
+            public string @__Expr3Get() {
+                return var2;
+            }
+            
+            public string ValueType___Expr3Get() {
+                this.GetValueTypeValues();
+                return this.@__Expr3Get();
+            }
+            
+            [System.Diagnostics.DebuggerHiddenAttribute()]
+            public void @__Expr3Set(string value) {
+                var2 = value;
+            }
+            
+            public void ValueType___Expr3Set(string value) {
+                this.GetValueTypeValues();
+                this.@__Expr3Set(value);
+                this.SetValueTypeValues();
+            }
+            
+            public new static bool Validate(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences, bool validateLocationCount, int offset) {
+                if (((validateLocationCount == true) 
+                            && (locationReferences.Count < 2))) {
+                    return false;
+                }
+                if ((validateLocationCount == true)) {
+                    offset = (locationReferences.Count - 2);
+                }
+                expectedLocationsCount = 2;
+                if (((locationReferences[(offset + 1)].Name != "var2") 
+                            || (locationReferences[(offset + 1)].Type != typeof(string)))) {
+                    return false;
+                }
+                return TestClass_TypedDataContext2.Validate(locationReferences, false, offset);
+            }
+        }
+        
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0")]
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        private class TestClass_TypedDataContext3_ForReadOnly : TestClass_TypedDataContext2_ForReadOnly {
+            
+            private int locationsOffset;
+            
+            private static int expectedLocationsCount;
+            
+            public TestClass_TypedDataContext3_ForReadOnly(System.Collections.Generic.IList<System.Activities.LocationReference> locations, System.Activities.ActivityContext activityContext, bool computelocationsOffset) : 
+                    base(locations, activityContext, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext3_ForReadOnly(System.Collections.Generic.IList<System.Activities.Location> locations, bool computelocationsOffset) : 
+                    base(locations, false) {
+                if ((computelocationsOffset == true)) {
+                    this.SetLocationsOffset((locations.Count - expectedLocationsCount));
+                }
+            }
+            
+            public TestClass_TypedDataContext3_ForReadOnly(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences) : 
+                    base(locationReferences) {
+            }
+            
+            protected string var2 {
+                get {
+                    return ((string)(this.GetVariableValue((1 + locationsOffset))));
+                }
+            }
+            
+            internal new static System.Activities.XamlIntegration.CompiledDataContext[] GetCompiledDataContextCacheHelper(object dataContextActivities, System.Activities.ActivityContext activityContext, System.Activities.Activity compiledRoot, bool forImplementation, int compiledDataContextCount) {
+                return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount);
+            }
+            
+            public new virtual void SetLocationsOffset(int locationsOffsetValue) {
+                locationsOffset = locationsOffsetValue;
+                base.SetLocationsOffset(locationsOffset);
+            }
+            
+            internal System.Linq.Expressions.Expression @__Expr4GetTree() {
+                System.Linq.Expressions.Expression<System.Func<string>> expression = () => var2;
+                return base.RewriteExpressionTree(expression);
+            }
+            
+            [System.Diagnostics.DebuggerHiddenAttribute()]
+            public string @__Expr4Get() {
+                return var2;
+            }
+            
+            public string ValueType___Expr4Get() {
+                this.GetValueTypeValues();
+                return this.@__Expr4Get();
+            }
+            
+            public new static bool Validate(System.Collections.Generic.IList<System.Activities.LocationReference> locationReferences, bool validateLocationCount, int offset) {
+                if (((validateLocationCount == true) 
+                            && (locationReferences.Count < 2))) {
+                    return false;
+                }
+                if ((validateLocationCount == true)) {
+                    offset = (locationReferences.Count - 2);
+                }
+                expectedLocationsCount = 2;
+                if (((locationReferences[(offset + 1)].Name != "var2") 
+                            || (locationReferences[(offset + 1)].Type != typeof(string)))) {
+                    return false;
+                }
+                return TestClass_TypedDataContext2_ForReadOnly.Validate(locationReferences, false, offset);
+            }
+        }
+    }
+}

--- a/src/Test/TestCases.Workflows/ExpressionCompilerResults/VB_ExpressionCompilerResult
+++ b/src/Test/TestCases.Workflows/ExpressionCompilerResults/VB_ExpressionCompilerResult
@@ -1,0 +1,778 @@
+Imports System
+Imports System.Collections
+Imports System.Collections.Generic
+Imports System.Activities
+Imports System.Activities.Expressions
+Imports System.Activities.Statements
+Imports System.Activities.XamlIntegration
+
+Namespace TestNamespace
+    
+    Public Class TestClass
+        Implements System.Activities.XamlIntegration.ICompiledExpressionRoot
+        
+        Private rootActivity As System.Activities.Activity
+        
+        Private dataContextActivities As Object
+        
+        Private forImplementation As Boolean = true
+        
+        Public Sub New(ByVal rootActivity As System.Activities.Activity)
+            MyBase.New
+            If (rootActivity Is Nothing) Then
+                Throw New System.ArgumentNullException("rootActivity")
+            End If
+            Me.rootActivity = rootActivity
+        End Sub
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Public Function GetLanguage() As String Implements System.Activities.XamlIntegration.ICompiledExpressionRoot.GetLanguage
+            Return "VB"
+        End Function
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Public Overloads Function InvokeExpression(ByVal expressionId As Integer, ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal activityContext As System.Activities.ActivityContext) As Object Implements System.Activities.XamlIntegration.ICompiledExpressionRoot.InvokeExpression
+            If (Me.dataContextActivities Is Nothing) Then
+                Me.dataContextActivities = TestClass_TypedDataContext2_ForReadOnly.GetDataContextActivitiesHelper(Me.rootActivity, Me.forImplementation)
+            End If
+            If (expressionId = 0) Then
+                Dim cachedCompiledDataContext() As System.Activities.XamlIntegration.CompiledDataContext = TestClass_TypedDataContext2_ForReadOnly.GetCompiledDataContextCacheHelper(Me.dataContextActivities, activityContext, Me.rootActivity, Me.forImplementation, 4)
+                If (cachedCompiledDataContext(0) Is Nothing) Then
+                    cachedCompiledDataContext(0) = New TestClass_TypedDataContext2_ForReadOnly(locations, activityContext, true)
+                End If
+                Dim valDataContext0 As TestClass_TypedDataContext2_ForReadOnly = CType(cachedCompiledDataContext(0),TestClass_TypedDataContext2_ForReadOnly)
+                Return valDataContext0.ValueType___Expr0Get
+            End If
+            If (expressionId = 1) Then
+                Dim cachedCompiledDataContext() As System.Activities.XamlIntegration.CompiledDataContext = TestClass_TypedDataContext2.GetCompiledDataContextCacheHelper(Me.dataContextActivities, activityContext, Me.rootActivity, Me.forImplementation, 4)
+                If (cachedCompiledDataContext(1) Is Nothing) Then
+                    cachedCompiledDataContext(1) = New TestClass_TypedDataContext2(locations, activityContext, true)
+                End If
+                Dim refDataContext1 As TestClass_TypedDataContext2 = CType(cachedCompiledDataContext(1),TestClass_TypedDataContext2)
+                Return refDataContext1.GetLocation(Of String)(AddressOf refDataContext1.ValueType___Expr1Get, AddressOf refDataContext1.ValueType___Expr1Set, expressionId, Me.rootActivity, activityContext)
+            End If
+            If (expressionId = 2) Then
+                Dim cachedCompiledDataContext() As System.Activities.XamlIntegration.CompiledDataContext = TestClass_TypedDataContext2_ForReadOnly.GetCompiledDataContextCacheHelper(Me.dataContextActivities, activityContext, Me.rootActivity, Me.forImplementation, 4)
+                If (cachedCompiledDataContext(0) Is Nothing) Then
+                    cachedCompiledDataContext(0) = New TestClass_TypedDataContext2_ForReadOnly(locations, activityContext, true)
+                End If
+                Dim valDataContext2 As TestClass_TypedDataContext2_ForReadOnly = CType(cachedCompiledDataContext(0),TestClass_TypedDataContext2_ForReadOnly)
+                Return valDataContext2.ValueType___Expr2Get
+            End If
+            If (expressionId = 3) Then
+                Dim cachedCompiledDataContext() As System.Activities.XamlIntegration.CompiledDataContext = TestClass_TypedDataContext3.GetCompiledDataContextCacheHelper(Me.dataContextActivities, activityContext, Me.rootActivity, Me.forImplementation, 4)
+                If (cachedCompiledDataContext(2) Is Nothing) Then
+                    cachedCompiledDataContext(2) = New TestClass_TypedDataContext3(locations, activityContext, true)
+                End If
+                Dim refDataContext3 As TestClass_TypedDataContext3 = CType(cachedCompiledDataContext(2),TestClass_TypedDataContext3)
+                Return refDataContext3.GetLocation(Of String)(AddressOf refDataContext3.ValueType___Expr3Get, AddressOf refDataContext3.ValueType___Expr3Set, expressionId, Me.rootActivity, activityContext)
+            End If
+            If (expressionId = 4) Then
+                Dim cachedCompiledDataContext() As System.Activities.XamlIntegration.CompiledDataContext = TestClass_TypedDataContext3_ForReadOnly.GetCompiledDataContextCacheHelper(Me.dataContextActivities, activityContext, Me.rootActivity, Me.forImplementation, 4)
+                If (cachedCompiledDataContext(3) Is Nothing) Then
+                    cachedCompiledDataContext(3) = New TestClass_TypedDataContext3_ForReadOnly(locations, activityContext, true)
+                End If
+                Dim valDataContext4 As TestClass_TypedDataContext3_ForReadOnly = CType(cachedCompiledDataContext(3),TestClass_TypedDataContext3_ForReadOnly)
+                Return valDataContext4.ValueType___Expr4Get
+            End If
+            If (expressionId = 5) Then
+                Dim cachedCompiledDataContext() As System.Activities.XamlIntegration.CompiledDataContext = TestClass_TypedDataContext2_ForReadOnly.GetCompiledDataContextCacheHelper(Me.dataContextActivities, activityContext, Me.rootActivity, Me.forImplementation, 4)
+                If (cachedCompiledDataContext(0) Is Nothing) Then
+                    cachedCompiledDataContext(0) = New TestClass_TypedDataContext2_ForReadOnly(locations, activityContext, true)
+                End If
+                Dim valDataContext5 As TestClass_TypedDataContext2_ForReadOnly = CType(cachedCompiledDataContext(0),TestClass_TypedDataContext2_ForReadOnly)
+                Return valDataContext5.ValueType___Expr5Get
+            End If
+            Return Nothing
+        End Function
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Public Overloads Function InvokeExpression(ByVal expressionId As Integer, ByVal locations As System.Collections.Generic.IList(Of System.Activities.Location)) As Object Implements System.Activities.XamlIntegration.ICompiledExpressionRoot.InvokeExpression
+            If (expressionId = 0) Then
+                Dim valDataContext0 As TestClass_TypedDataContext2_ForReadOnly = New TestClass_TypedDataContext2_ForReadOnly(locations, true)
+                Return valDataContext0.ValueType___Expr0Get
+            End If
+            If (expressionId = 1) Then
+                Dim refDataContext1 As TestClass_TypedDataContext2 = New TestClass_TypedDataContext2(locations, true)
+                Return refDataContext1.GetLocation(Of String)(AddressOf refDataContext1.ValueType___Expr1Get, AddressOf refDataContext1.ValueType___Expr1Set)
+            End If
+            If (expressionId = 2) Then
+                Dim valDataContext2 As TestClass_TypedDataContext2_ForReadOnly = New TestClass_TypedDataContext2_ForReadOnly(locations, true)
+                Return valDataContext2.ValueType___Expr2Get
+            End If
+            If (expressionId = 3) Then
+                Dim refDataContext3 As TestClass_TypedDataContext3 = New TestClass_TypedDataContext3(locations, true)
+                Return refDataContext3.GetLocation(Of String)(AddressOf refDataContext3.ValueType___Expr3Get, AddressOf refDataContext3.ValueType___Expr3Set)
+            End If
+            If (expressionId = 4) Then
+                Dim valDataContext4 As TestClass_TypedDataContext3_ForReadOnly = New TestClass_TypedDataContext3_ForReadOnly(locations, true)
+                Return valDataContext4.ValueType___Expr4Get
+            End If
+            If (expressionId = 5) Then
+                Dim valDataContext5 As TestClass_TypedDataContext2_ForReadOnly = New TestClass_TypedDataContext2_ForReadOnly(locations, true)
+                Return valDataContext5.ValueType___Expr5Get
+            End If
+            Return Nothing
+        End Function
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Public Overloads Function CanExecuteExpression(ByVal type As System.Type, ByVal expressionText As String, ByVal isReference As Boolean, ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByRef expressionId As Integer) As Boolean Implements System.Activities.XamlIntegration.ICompiledExpressionRoot.CanExecuteExpression
+            If (((isReference = false)  _
+                        AndAlso (type = GetType(String)))  _
+                        AndAlso ((expressionText = "var1")  _
+                        AndAlso (TestClass_TypedDataContext2_ForReadOnly.Validate(locations, true, 0) = true))) Then
+                expressionId = 0
+                Return true
+            End If
+            If (((isReference = true)  _
+                        AndAlso (type = GetType(String)))  _
+                        AndAlso ((expressionText = "var1")  _
+                        AndAlso (TestClass_TypedDataContext2.Validate(locations, true, 0) = true))) Then
+                expressionId = 1
+                Return true
+            End If
+            If (((isReference = false)  _
+                        AndAlso (type = GetType(Boolean)))  _
+                        AndAlso ((expressionText = "var1 != ""test""")  _
+                        AndAlso (TestClass_TypedDataContext2_ForReadOnly.Validate(locations, true, 0) = true))) Then
+                expressionId = 2
+                Return true
+            End If
+            If (((isReference = true)  _
+                        AndAlso (type = GetType(String)))  _
+                        AndAlso ((expressionText = "var2")  _
+                        AndAlso (TestClass_TypedDataContext3.Validate(locations, true, 0) = true))) Then
+                expressionId = 3
+                Return true
+            End If
+            If (((isReference = false)  _
+                        AndAlso (type = GetType(String)))  _
+                        AndAlso ((expressionText = "var2")  _
+                        AndAlso (TestClass_TypedDataContext3_ForReadOnly.Validate(locations, true, 0) = true))) Then
+                expressionId = 4
+                Return true
+            End If
+            If (((isReference = false)  _
+                        AndAlso (type = GetType(String)))  _
+                        AndAlso ((expressionText = "test3")  _
+                        AndAlso (TestClass_TypedDataContext2_ForReadOnly.Validate(locations, true, 0) = true))) Then
+                expressionId = 5
+                Return true
+            End If
+            expressionId = -1
+            Return false
+        End Function
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Public Overloads Function CanExecuteExpression(ByVal expressionText As String, ByVal isReference As Boolean, ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByRef expressionId As Integer) As Boolean Implements System.Activities.XamlIntegration.ICompiledExpressionRoot.CanExecuteExpression
+            Throw New System.NotImplementedException()
+        End Function
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Public Function GetRequiredLocations(ByVal expressionId As Integer) As System.Collections.Generic.IList(Of String) Implements System.Activities.XamlIntegration.ICompiledExpressionRoot.GetRequiredLocations
+            Dim returnLocations As System.Collections.Generic.List(Of String) = New System.Collections.Generic.List(Of String)()
+            If (expressionId = 0) Then
+            End If
+            If (expressionId = 1) Then
+            End If
+            If (expressionId = 2) Then
+            End If
+            If (expressionId = 3) Then
+            End If
+            If (expressionId = 4) Then
+            End If
+            If (expressionId = 5) Then
+            End If
+            Return returnLocations
+        End Function
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Public Function GetExpressionTreeForExpression(ByVal expressionId As Integer, ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference)) As System.Linq.Expressions.Expression Implements System.Activities.XamlIntegration.ICompiledExpressionRoot.GetExpressionTreeForExpression
+            If (expressionId = 0) Then
+                Return New TestClass_TypedDataContext2_ForReadOnly(locationReferences).__Expr0GetTree
+            End If
+            If (expressionId = 1) Then
+                Return New TestClass_TypedDataContext2(locationReferences).__Expr1GetTree
+            End If
+            If (expressionId = 2) Then
+                Return New TestClass_TypedDataContext2_ForReadOnly(locationReferences).__Expr2GetTree
+            End If
+            If (expressionId = 3) Then
+                Return New TestClass_TypedDataContext3(locationReferences).__Expr3GetTree
+            End If
+            If (expressionId = 4) Then
+                Return New TestClass_TypedDataContext3_ForReadOnly(locationReferences).__Expr4GetTree
+            End If
+            If (expressionId = 5) Then
+                Return New TestClass_TypedDataContext2_ForReadOnly(locationReferences).__Expr5GetTree
+            End If
+            Return Nothing
+        End Function
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Private Class TestClass_TypedDataContext0
+            Inherits System.Activities.XamlIntegration.CompiledDataContext
+            
+            Private locationsOffset As Integer
+            
+            Private Shared expectedLocationsCount As Integer
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal activityContext As System.Activities.ActivityContext, ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, activityContext)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.Location), ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference))
+                MyBase.New(locationReferences)
+            End Sub
+            
+            Friend Shared Function GetDataContextActivitiesHelper(ByVal compiledRoot As System.Activities.Activity, ByVal forImplementation As Boolean) As Object
+                Return System.Activities.XamlIntegration.CompiledDataContext.GetDataContextActivities(compiledRoot, forImplementation)
+            End Function
+            
+            Friend Shared Function GetCompiledDataContextCacheHelper(ByVal dataContextActivities As Object, ByVal activityContext As System.Activities.ActivityContext, ByVal compiledRoot As System.Activities.Activity, ByVal forImplementation As Boolean, ByVal compiledDataContextCount As Integer) As System.Activities.XamlIntegration.CompiledDataContext()
+                Return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount)
+            End Function
+            
+            Public Overridable Sub SetLocationsOffset(ByVal locationsOffsetValue As Integer)
+                locationsOffset = locationsOffsetValue
+            End Sub
+            
+            Public Shared Function Validate(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal validateLocationCount As Boolean, ByVal offset As Integer) As Boolean
+                If ((validateLocationCount = true)  _
+                            AndAlso (locationReferences.Count < 0)) Then
+                    Return false
+                End If
+                expectedLocationsCount = 0
+                Return true
+            End Function
+        End Class
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Private Class TestClass_TypedDataContext0_ForReadOnly
+            Inherits System.Activities.XamlIntegration.CompiledDataContext
+            
+            Private locationsOffset As Integer
+            
+            Private Shared expectedLocationsCount As Integer
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal activityContext As System.Activities.ActivityContext, ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, activityContext)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.Location), ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference))
+                MyBase.New(locationReferences)
+            End Sub
+            
+            Friend Shared Function GetDataContextActivitiesHelper(ByVal compiledRoot As System.Activities.Activity, ByVal forImplementation As Boolean) As Object
+                Return System.Activities.XamlIntegration.CompiledDataContext.GetDataContextActivities(compiledRoot, forImplementation)
+            End Function
+            
+            Friend Shared Function GetCompiledDataContextCacheHelper(ByVal dataContextActivities As Object, ByVal activityContext As System.Activities.ActivityContext, ByVal compiledRoot As System.Activities.Activity, ByVal forImplementation As Boolean, ByVal compiledDataContextCount As Integer) As System.Activities.XamlIntegration.CompiledDataContext()
+                Return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount)
+            End Function
+            
+            Public Overridable Sub SetLocationsOffset(ByVal locationsOffsetValue As Integer)
+                locationsOffset = locationsOffsetValue
+            End Sub
+            
+            Public Shared Function Validate(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal validateLocationCount As Boolean, ByVal offset As Integer) As Boolean
+                If ((validateLocationCount = true)  _
+                            AndAlso (locationReferences.Count < 0)) Then
+                    Return false
+                End If
+                expectedLocationsCount = 0
+                Return true
+            End Function
+        End Class
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Private Class TestClass_TypedDataContext1
+            Inherits TestClass_TypedDataContext0
+            
+            Private locationsOffset As Integer
+            
+            Private Shared expectedLocationsCount As Integer
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal activityContext As System.Activities.ActivityContext, ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, activityContext, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.Location), ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference))
+                MyBase.New(locationReferences)
+            End Sub
+            
+            Friend Shadows Shared Function GetCompiledDataContextCacheHelper(ByVal dataContextActivities As Object, ByVal activityContext As System.Activities.ActivityContext, ByVal compiledRoot As System.Activities.Activity, ByVal forImplementation As Boolean, ByVal compiledDataContextCount As Integer) As System.Activities.XamlIntegration.CompiledDataContext()
+                Return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount)
+            End Function
+            
+            Public Shadows Overridable Sub SetLocationsOffset(ByVal locationsOffsetValue As Integer)
+                locationsOffset = locationsOffsetValue
+                MyBase.SetLocationsOffset(locationsOffset)
+            End Sub
+            
+            Public Shadows Shared Function Validate(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal validateLocationCount As Boolean, ByVal offset As Integer) As Boolean
+                If ((validateLocationCount = true)  _
+                            AndAlso (locationReferences.Count < 0)) Then
+                    Return false
+                End If
+                expectedLocationsCount = 0
+                Return TestClass_TypedDataContext0.Validate(locationReferences, false, offset)
+            End Function
+        End Class
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Private Class TestClass_TypedDataContext1_ForReadOnly
+            Inherits TestClass_TypedDataContext0_ForReadOnly
+            
+            Private locationsOffset As Integer
+            
+            Private Shared expectedLocationsCount As Integer
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal activityContext As System.Activities.ActivityContext, ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, activityContext, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.Location), ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference))
+                MyBase.New(locationReferences)
+            End Sub
+            
+            Friend Shadows Shared Function GetCompiledDataContextCacheHelper(ByVal dataContextActivities As Object, ByVal activityContext As System.Activities.ActivityContext, ByVal compiledRoot As System.Activities.Activity, ByVal forImplementation As Boolean, ByVal compiledDataContextCount As Integer) As System.Activities.XamlIntegration.CompiledDataContext()
+                Return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount)
+            End Function
+            
+            Public Shadows Overridable Sub SetLocationsOffset(ByVal locationsOffsetValue As Integer)
+                locationsOffset = locationsOffsetValue
+                MyBase.SetLocationsOffset(locationsOffset)
+            End Sub
+            
+            Public Shadows Shared Function Validate(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal validateLocationCount As Boolean, ByVal offset As Integer) As Boolean
+                If ((validateLocationCount = true)  _
+                            AndAlso (locationReferences.Count < 0)) Then
+                    Return false
+                End If
+                expectedLocationsCount = 0
+                Return TestClass_TypedDataContext0_ForReadOnly.Validate(locationReferences, false, offset)
+            End Function
+        End Class
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Private Class TestClass_TypedDataContext2
+            Inherits TestClass_TypedDataContext1
+            
+            Private locationsOffset As Integer
+            
+            Private Shared expectedLocationsCount As Integer
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal activityContext As System.Activities.ActivityContext, ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, activityContext, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.Location), ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference))
+                MyBase.New(locationReferences)
+            End Sub
+            
+            Protected Property var1() As String
+                Get
+                    Return CType(Me.GetVariableValue((0 + locationsOffset)),String)
+                End Get
+                Set
+                    Me.SetVariableValue((0 + locationsOffset), value)
+                End Set
+            End Property
+            
+            Friend Shadows Shared Function GetCompiledDataContextCacheHelper(ByVal dataContextActivities As Object, ByVal activityContext As System.Activities.ActivityContext, ByVal compiledRoot As System.Activities.Activity, ByVal forImplementation As Boolean, ByVal compiledDataContextCount As Integer) As System.Activities.XamlIntegration.CompiledDataContext()
+                Return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount)
+            End Function
+            
+            Public Shadows Overridable Sub SetLocationsOffset(ByVal locationsOffsetValue As Integer)
+                locationsOffset = locationsOffsetValue
+                MyBase.SetLocationsOffset(locationsOffset)
+            End Sub
+            
+            Friend Function __Expr1GetTree() As System.Linq.Expressions.Expression
+                Dim expression As System.Linq.Expressions.Expression(Of System.Func(Of String)) = Function() var1
+                Return MyBase.RewriteExpressionTree(expression)
+            End Function
+            
+            <System.Diagnostics.DebuggerHiddenAttribute()>  _
+            Public Function __Expr1Get() As String
+                Return var1
+            End Function
+            
+            Public Function ValueType___Expr1Get() As String
+                Me.GetValueTypeValues
+                Return Me.__Expr1Get
+            End Function
+            
+            <System.Diagnostics.DebuggerHiddenAttribute()>  _
+            Public Sub __Expr1Set(ByVal value As String)
+                var1 = value
+            End Sub
+            
+            Public Sub ValueType___Expr1Set(ByVal value As String)
+                Me.GetValueTypeValues
+                Me.__Expr1Set(value)
+                Me.SetValueTypeValues
+            End Sub
+            
+            Public Shadows Shared Function Validate(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal validateLocationCount As Boolean, ByVal offset As Integer) As Boolean
+                If ((validateLocationCount = true)  _
+                            AndAlso (locationReferences.Count < 1)) Then
+                    Return false
+                End If
+                If (validateLocationCount = true) Then
+                    offset = (locationReferences.Count - 1)
+                End If
+                expectedLocationsCount = 1
+                If ((locationReferences((offset + 0)).Name <> "var1")  _
+                            OrElse (locationReferences((offset + 0)).Type <> GetType(String))) Then
+                    Return false
+                End If
+                Return TestClass_TypedDataContext1.Validate(locationReferences, false, offset)
+            End Function
+        End Class
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Private Class TestClass_TypedDataContext2_ForReadOnly
+            Inherits TestClass_TypedDataContext1_ForReadOnly
+            
+            Private locationsOffset As Integer
+            
+            Private Shared expectedLocationsCount As Integer
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal activityContext As System.Activities.ActivityContext, ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, activityContext, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.Location), ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference))
+                MyBase.New(locationReferences)
+            End Sub
+            
+            Protected ReadOnly Property var1() As String
+                Get
+                    Return CType(Me.GetVariableValue((0 + locationsOffset)),String)
+                End Get
+            End Property
+            
+            Friend Shadows Shared Function GetCompiledDataContextCacheHelper(ByVal dataContextActivities As Object, ByVal activityContext As System.Activities.ActivityContext, ByVal compiledRoot As System.Activities.Activity, ByVal forImplementation As Boolean, ByVal compiledDataContextCount As Integer) As System.Activities.XamlIntegration.CompiledDataContext()
+                Return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount)
+            End Function
+            
+            Public Shadows Overridable Sub SetLocationsOffset(ByVal locationsOffsetValue As Integer)
+                locationsOffset = locationsOffsetValue
+                MyBase.SetLocationsOffset(locationsOffset)
+            End Sub
+            
+            Friend Function __Expr0GetTree() As System.Linq.Expressions.Expression
+                Dim expression As System.Linq.Expressions.Expression(Of System.Func(Of String)) = Function() var1
+                Return MyBase.RewriteExpressionTree(expression)
+            End Function
+            
+            <System.Diagnostics.DebuggerHiddenAttribute()>  _
+            Public Function __Expr0Get() As String
+                Return var1
+            End Function
+            
+            Public Function ValueType___Expr0Get() As String
+                Me.GetValueTypeValues
+                Return Me.__Expr0Get
+            End Function
+            
+            Friend Function __Expr2GetTree() As System.Linq.Expressions.Expression
+                Dim expression As System.Linq.Expressions.Expression(Of System.Func(Of Boolean)) = Function() var1 != "test"
+                Return MyBase.RewriteExpressionTree(expression)
+            End Function
+            
+            <System.Diagnostics.DebuggerHiddenAttribute()>  _
+            Public Function __Expr2Get() As Boolean
+                Return var1 != "test"
+            End Function
+            
+            Public Function ValueType___Expr2Get() As Boolean
+                Me.GetValueTypeValues
+                Return Me.__Expr2Get
+            End Function
+            
+            Friend Function __Expr5GetTree() As System.Linq.Expressions.Expression
+                Dim expression As System.Linq.Expressions.Expression(Of System.Func(Of String)) = Function() test3
+                Return MyBase.RewriteExpressionTree(expression)
+            End Function
+            
+            <System.Diagnostics.DebuggerHiddenAttribute()>  _
+            Public Function __Expr5Get() As String
+                Return test3
+            End Function
+            
+            Public Function ValueType___Expr5Get() As String
+                Me.GetValueTypeValues
+                Return Me.__Expr5Get
+            End Function
+            
+            Public Shadows Shared Function Validate(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal validateLocationCount As Boolean, ByVal offset As Integer) As Boolean
+                If ((validateLocationCount = true)  _
+                            AndAlso (locationReferences.Count < 1)) Then
+                    Return false
+                End If
+                If (validateLocationCount = true) Then
+                    offset = (locationReferences.Count - 1)
+                End If
+                expectedLocationsCount = 1
+                If ((locationReferences((offset + 0)).Name <> "var1")  _
+                            OrElse (locationReferences((offset + 0)).Type <> GetType(String))) Then
+                    Return false
+                End If
+                Return TestClass_TypedDataContext1_ForReadOnly.Validate(locationReferences, false, offset)
+            End Function
+        End Class
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Private Class TestClass_TypedDataContext3
+            Inherits TestClass_TypedDataContext2
+            
+            Private locationsOffset As Integer
+            
+            Private Shared expectedLocationsCount As Integer
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal activityContext As System.Activities.ActivityContext, ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, activityContext, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.Location), ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference))
+                MyBase.New(locationReferences)
+            End Sub
+            
+            Protected Property var2() As String
+                Get
+                    Return CType(Me.GetVariableValue((1 + locationsOffset)),String)
+                End Get
+                Set
+                    Me.SetVariableValue((1 + locationsOffset), value)
+                End Set
+            End Property
+            
+            Friend Shadows Shared Function GetCompiledDataContextCacheHelper(ByVal dataContextActivities As Object, ByVal activityContext As System.Activities.ActivityContext, ByVal compiledRoot As System.Activities.Activity, ByVal forImplementation As Boolean, ByVal compiledDataContextCount As Integer) As System.Activities.XamlIntegration.CompiledDataContext()
+                Return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount)
+            End Function
+            
+            Public Shadows Overridable Sub SetLocationsOffset(ByVal locationsOffsetValue As Integer)
+                locationsOffset = locationsOffsetValue
+                MyBase.SetLocationsOffset(locationsOffset)
+            End Sub
+            
+            Friend Function __Expr3GetTree() As System.Linq.Expressions.Expression
+                Dim expression As System.Linq.Expressions.Expression(Of System.Func(Of String)) = Function() var2
+                Return MyBase.RewriteExpressionTree(expression)
+            End Function
+            
+            <System.Diagnostics.DebuggerHiddenAttribute()>  _
+            Public Function __Expr3Get() As String
+                Return var2
+            End Function
+            
+            Public Function ValueType___Expr3Get() As String
+                Me.GetValueTypeValues
+                Return Me.__Expr3Get
+            End Function
+            
+            <System.Diagnostics.DebuggerHiddenAttribute()>  _
+            Public Sub __Expr3Set(ByVal value As String)
+                var2 = value
+            End Sub
+            
+            Public Sub ValueType___Expr3Set(ByVal value As String)
+                Me.GetValueTypeValues
+                Me.__Expr3Set(value)
+                Me.SetValueTypeValues
+            End Sub
+            
+            Public Shadows Shared Function Validate(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal validateLocationCount As Boolean, ByVal offset As Integer) As Boolean
+                If ((validateLocationCount = true)  _
+                            AndAlso (locationReferences.Count < 2)) Then
+                    Return false
+                End If
+                If (validateLocationCount = true) Then
+                    offset = (locationReferences.Count - 2)
+                End If
+                expectedLocationsCount = 2
+                If ((locationReferences((offset + 1)).Name <> "var2")  _
+                            OrElse (locationReferences((offset + 1)).Type <> GetType(String))) Then
+                    Return false
+                End If
+                Return TestClass_TypedDataContext2.Validate(locationReferences, false, offset)
+            End Function
+        End Class
+        
+        <System.CodeDom.Compiler.GeneratedCodeAttribute("UiPath.Workflow", "6.0.0.0"),  _
+         System.ComponentModel.BrowsableAttribute(false),  _
+         System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)>  _
+        Private Class TestClass_TypedDataContext3_ForReadOnly
+            Inherits TestClass_TypedDataContext2_ForReadOnly
+            
+            Private locationsOffset As Integer
+            
+            Private Shared expectedLocationsCount As Integer
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal activityContext As System.Activities.ActivityContext, ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, activityContext, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locations As System.Collections.Generic.IList(Of System.Activities.Location), ByVal computelocationsOffset As Boolean)
+                MyBase.New(locations, false)
+                If (computelocationsOffset = true) Then
+                    Me.SetLocationsOffset((locations.Count - expectedLocationsCount))
+                End If
+            End Sub
+            
+            Public Sub New(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference))
+                MyBase.New(locationReferences)
+            End Sub
+            
+            Protected ReadOnly Property var2() As String
+                Get
+                    Return CType(Me.GetVariableValue((1 + locationsOffset)),String)
+                End Get
+            End Property
+            
+            Friend Shadows Shared Function GetCompiledDataContextCacheHelper(ByVal dataContextActivities As Object, ByVal activityContext As System.Activities.ActivityContext, ByVal compiledRoot As System.Activities.Activity, ByVal forImplementation As Boolean, ByVal compiledDataContextCount As Integer) As System.Activities.XamlIntegration.CompiledDataContext()
+                Return System.Activities.XamlIntegration.CompiledDataContext.GetCompiledDataContextCache(dataContextActivities, activityContext, compiledRoot, forImplementation, compiledDataContextCount)
+            End Function
+            
+            Public Shadows Overridable Sub SetLocationsOffset(ByVal locationsOffsetValue As Integer)
+                locationsOffset = locationsOffsetValue
+                MyBase.SetLocationsOffset(locationsOffset)
+            End Sub
+            
+            Friend Function __Expr4GetTree() As System.Linq.Expressions.Expression
+                Dim expression As System.Linq.Expressions.Expression(Of System.Func(Of String)) = Function() var2
+                Return MyBase.RewriteExpressionTree(expression)
+            End Function
+            
+            <System.Diagnostics.DebuggerHiddenAttribute()>  _
+            Public Function __Expr4Get() As String
+                Return var2
+            End Function
+            
+            Public Function ValueType___Expr4Get() As String
+                Me.GetValueTypeValues
+                Return Me.__Expr4Get
+            End Function
+            
+            Public Shadows Shared Function Validate(ByVal locationReferences As System.Collections.Generic.IList(Of System.Activities.LocationReference), ByVal validateLocationCount As Boolean, ByVal offset As Integer) As Boolean
+                If ((validateLocationCount = true)  _
+                            AndAlso (locationReferences.Count < 2)) Then
+                    Return false
+                End If
+                If (validateLocationCount = true) Then
+                    offset = (locationReferences.Count - 2)
+                End If
+                expectedLocationsCount = 2
+                If ((locationReferences((offset + 1)).Name <> "var2")  _
+                            OrElse (locationReferences((offset + 1)).Type <> GetType(String))) Then
+                    Return false
+                End If
+                Return TestClass_TypedDataContext2_ForReadOnly.Validate(locationReferences, false, offset)
+            End Function
+        End Class
+    End Class
+End Namespace

--- a/src/Test/TestCases.Workflows/ExpressionTests.cs
+++ b/src/Test/TestCases.Workflows/ExpressionTests.cs
@@ -6,6 +6,7 @@ using System.Activities;
 using System.Activities.Expressions;
 using System.Activities.Statements;
 using System.Activities.Validation;
+using System.Activities.XamlIntegration;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -565,5 +566,99 @@ public class ExpressionTests
         seq.Activities.Add(new WriteLine { Text = new InArgument<string>(new VisualBasicValue<string>("abc")) });
         var valid = ActivityValidationServices.Validate(seq, _useValidator);
         valid.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void VB_CompileAndInvokeActivityWithValueInImplementation()
+    {
+        foreach (var activity in GetActivitiesWithVBValues())
+        {
+            var root = new DynamicActivity { Implementation = () => activity };
+            ActivityXamlServices.Compile(root, new() { CompileExpressions = true });
+            WorkflowInvoker.Invoke(root);
+        }
+    }
+
+    [Fact]
+    public void CS_CompileAndInvokeActivityWithValueInImplementation()
+    {
+        foreach (var activity in GetActivitiesWithCSValues())
+        {
+            var root = new DynamicActivity { Implementation = () => activity };
+            ActivityXamlServices.Compile(root, new() { CompileExpressions = true });
+            WorkflowInvoker.Invoke(root);
+        }
+    }
+
+    private static IEnumerable<Activity> GetActivitiesWithVBValues()
+    {
+        yield return new ActivityWithVBValue("(1 + 2).ToString");
+        yield return new ActivityWithMultipleNestedVBValues();
+    }
+
+    private static IEnumerable<Activity> GetActivitiesWithCSValues()
+    {
+        yield return new ActivityWithCSValue("(1 + 2).ToString()");
+        yield return new ActivityWithMultipleNestedCSValues();
+    }
+
+    private class ActivityWithVBValue : Activity
+    {
+        public ActivityWithVBValue(string expressionText)
+        {
+            Implementation = () => new WriteLine() { Text = new InArgument<string>(new VisualBasicValue<string>(expressionText)) };
+        }
+    }
+
+    private class ActivityWithCSValue : Activity
+    {
+        public ActivityWithCSValue(string expressionText)
+        {
+            Implementation = () => new WriteLine() { Text = new InArgument<string>(new CSharpValue<string>(expressionText)) };
+        }
+    }
+
+    private class ActivityWithMultipleNestedVBValues : Activity
+    {
+        public ActivityWithMultipleNestedVBValues()
+        {
+            Implementation = () => new Sequence()
+            {
+                Activities =
+                {
+                    new ActivityWithVBValue("99.ToString"),
+                    new Sequence()
+                    {
+                        Activities =
+                        {
+                            new ActivityWithVBValue("(1 + 2).ToString"),
+                        }
+                    },
+                    new ActivityWithVBValue("{1, 2, 3}.ToString")
+                }
+            };
+        }
+    }
+
+    private class ActivityWithMultipleNestedCSValues : Activity
+    {
+        public ActivityWithMultipleNestedCSValues()
+        {
+            Implementation = () => new Sequence()
+            {
+                Activities =
+                {
+                    new ActivityWithCSValue("99.ToString()"),
+                    new Sequence()
+                    {
+                        Activities =
+                        {
+                            new ActivityWithCSValue("(1 + 2).ToString()"),
+                        }
+                    },
+                    new ActivityWithCSValue("(new int[] {1, 2, 3}).ToString()") 
+                }
+            };
+        }
     }
 }

--- a/src/Test/TestCases.Workflows/TestCases.Workflows.csproj
+++ b/src/Test/TestCases.Workflows/TestCases.Workflows.csproj
@@ -6,6 +6,10 @@
   <ItemGroup>
     <Page Remove="**\*.xaml" />
     <EmbeddedResource Include="TestXamls\*.xaml" />
+    <Page Remove="ExpressionCompilerResults\CS_ExpressionCompilerResult" />
+    <Page Remove="ExpressionCompilerResults\VB_ExpressionCompilerResult" />
+    <EmbeddedResource Include="ExpressionCompilerResults\CS_ExpressionCompilerResult" />
+    <EmbeddedResource Include="ExpressionCompilerResults\VB_ExpressionCompilerResult" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AgileObjects.ReadableExpressions" Version="3.1.0" />

--- a/src/Test/TestCases.Workflows/TextExpressionCompilerTests.cs
+++ b/src/Test/TestCases.Workflows/TextExpressionCompilerTests.cs
@@ -1,0 +1,103 @@
+﻿using Xunit;
+using System;
+using System.IO;
+using System.Activities;
+using Microsoft.CSharp.Activities;
+using System.Activities.Statements;
+using Microsoft.VisualBasic.Activities;
+using System.Activities.XamlIntegration;
+
+namespace TestCases.Workflows
+{
+    public class TextExpressionCompilerTests
+    {
+        [Theory]
+        [InlineData("VB")]
+        [InlineData("C#")]
+        public void EnsureCompilationParity(string expressionLanguage)
+        {
+            var actualSourceWriter = new StringWriter();
+            var currentAsm = typeof(TextExpressionCompilerTests).Assembly;
+
+            TextExpressionCompilerSettings settings = new()
+            {
+                RootNamespace = null,
+                ForImplementation = true,
+                ActivityName = "TestClass",
+                AlwaysGenerateSource = true,
+                Language = expressionLanguage,
+                GenerateAsPartialClass = false,
+                ActivityNamespace = "TestNamespace",
+                Activity = new DynamicActivity { Implementation = () => GetActivity(expressionLanguage) },
+            };
+
+            new TextExpressionCompiler(settings).GenerateSource(actualSourceWriter);
+            var expectedStream = currentAsm.GetManifestResourceStream($"{currentAsm.GetName().Name}.ExpressionCompilerResults.{GetExpectedResourceName(expressionLanguage)}");
+
+            var actualSource = actualSourceWriter.ToString();
+            var expectedSource = new StreamReader(expectedStream).ReadToEnd();
+            Assert.Equal(expectedSource, actualSource);
+        }
+
+        private static string GetExpectedResourceName(string expressionLanguage)
+            => expressionLanguage switch
+            {
+                "C#" => "CS_ExpressionCompilerResult",
+                "VB" => "VB_ExpressionCompilerResult",
+                _ => throw new NotImplementedException()
+            };
+
+        private static Activity GetActivity(string expressionLanguage)
+            => expressionLanguage switch
+            {
+                "C#" => GetActivity(v1 => new CSharpValue<bool>(v1), v2 => new CSharpValue<string>(v2), v3 => new CSharpReference<string>(v3)),
+                "VB" => GetActivity(v1 => new VisualBasicValue<bool>(v1), v2 => new VisualBasicValue<string>(v2), v3 => new VisualBasicReference<string>(v3)),
+                _ => throw new NotImplementedException()
+            };
+
+        private static Activity GetActivity<T1, T2, T3>(Func<string, T1> boolValueFactory, Func<string, T2> strValueFactory, Func<string, T3> referenceFactory)
+            where T1 : TextExpressionBase<bool>
+            where T2 : TextExpressionBase<string>
+            where T3 : TextExpressionBase<Location<string>>
+            => new Sequence()
+            {
+                Variables =
+                {
+                    new Variable<string>("var1")
+                },
+                Activities =
+                {
+                    new WriteLine() { Text = new InArgument<string>(strValueFactory("var1")) },
+                    new Assign() { To = new OutArgument<string>(referenceFactory("var1")), Value = new InArgument<string>("test1") },
+                    new If() {
+                        Condition = new InArgument<bool>(boolValueFactory("var1 != \"test\"")),
+                        Then = new Sequence()
+                        {
+                            Variables =
+                            {
+                                new Variable<string>("var2")
+                            },
+                            Activities =
+                            {
+                                new Assign() { To = new OutArgument<string>(referenceFactory("var2")), Value = new InArgument<string>("test2") },
+                                new WriteLine() { Text = new InArgument<string>(strValueFactory("var2")) },
+                            }
+                        },
+                        Else = new Sequence()
+                        {
+                            Activities =
+                            {
+                                new Sequence()
+                                {
+                                    Activities =
+                                    {
+                                        new WriteLine() { Text = new InArgument<string>(strValueFactory("test3")) },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+    }
+}

--- a/src/UiPath.Workflow.Runtime/Expressions/CompiledExpressionInvoker.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/CompiledExpressionInvoker.cs
@@ -169,16 +169,14 @@ public class CompiledExpressionInvoker
     {
         ActivityInstance current = activityContext.CurrentInstance;
 
-        while (current != null && current.Activity != _metadataRoot)
+        while (current != null)
         {
-
-            if (TryGetCompiledExpressionRoot(current.Activity, true, out ICompiledExpressionRoot currentCompiledExpressionRoot))
+            if (current.Activity != _metadataRoot 
+                && TryGetCompiledExpressionRoot(current.Activity, true, out ICompiledExpressionRoot currentCompiledExpressionRoot)
+                && CanExecuteExpression(currentCompiledExpressionRoot, out expressionId))
             {
-                if (CanExecuteExpression(currentCompiledExpressionRoot, out expressionId))
-                {
-                    compiledExpressionRoot = currentCompiledExpressionRoot;
-                    return true;
-                }
+                compiledExpressionRoot = currentCompiledExpressionRoot;
+                return true;
             }
             current = current.Parent;
         }

--- a/src/UiPath.Workflow.Runtime/XamlIntegration/CompiledExpressionActivityVisitor.cs
+++ b/src/UiPath.Workflow.Runtime/XamlIntegration/CompiledExpressionActivityVisitor.cs
@@ -56,6 +56,12 @@ internal abstract class CompiledExpressionActivityVisitor
         {
             return;
         }
+
+        VisitImplementationChildren(activity, out exit);
+        if (exit)
+        {
+            return;
+        }
     }
 
     protected virtual void VisitRoot(Activity activity, out bool exit)
@@ -196,6 +202,22 @@ internal abstract class CompiledExpressionActivityVisitor
             for (int i = 0; i < activity.ImportedChildren.Count; i++)
             {
                 VisitCore(activity.ImportedChildren[i], out exit);
+                if (exit)
+                {
+                    return;
+                }
+            }
+        }
+        exit = false;
+    }
+
+    protected virtual void VisitImplementationChildren(Activity activity, out bool exit)
+    {
+        if (activity.ImplementationChildren is not null)
+        {
+            for (int i = 0; i < activity.ImplementationChildren.Count; i++)
+            {
+                VisitCore(activity.ImplementationChildren[i], out exit);
                 if (exit)
                 {
                     return;
@@ -370,18 +392,11 @@ internal abstract class CompiledExpressionActivityVisitor
             return;
         }
 
-        if (activity.ImplementationChildren != null)
+        VisitImplementationChildren(activity, out exit);
+        if (exit)
         {
-            for (int i = 0; i < activity.ImplementationChildren.Count; i++)
-            {
-                VisitCore(activity.ImplementationChildren[i], out exit);
-                if (exit)
-                {
-                    return;
-                }
-            }
+            return;
         }
-        exit = false;
     }
 
     private void VisitPublicActivities(Activity activity, out bool exit)


### PR DESCRIPTION
The `CompiledExpressionActivityVisitor` parser doesn't find expressions from an activity `Implementation`. This means that those expressions won't have a `CompiledExpressionRoot` and will rely on legacy code to compile for VB and for C# doesn't work at all.

Here is an example of an activity that will not have the expression compiled:
```cs
class ActivityWithVBValue : Activity
{
    public ActivityWithVBValue()
    {
        Implementation = () => new WriteLine() 
        { 
            Text = new InArgument<string>(new VisualBasicValue<string>("will not compile")) 
        };
    }
}
```