### PR TITLE
Use argument display name for validation message when available instead of its name STUD-68550

### DIFF
--- a/src/Test/TestCases.Runtime/ValidationHelperTests.cs
+++ b/src/Test/TestCases.Runtime/ValidationHelperTests.cs
@@ -1,0 +1,58 @@
+﻿using Shouldly;
+using System;
+using System.Activities;
+using System.Activities.Statements;
+using System.Activities.ParallelTracking;
+using System.Collections.Generic;
+using System.Linq;
+using WorkflowApplicationTestExtensions;
+using Xunit;
+using System.Activities.Validation;
+using static System.Activities.Validation.ValidationHelper;
+using System.ComponentModel;
+
+namespace TestCases.Runtime;
+
+public class ValidationHelperTests
+{
+    [Fact]
+    public void ValidateArguments_UsesDisplayNameOfArgument()
+    {
+        var activity = new Sequence();
+        var property = TypeDescriptor.GetProperties(activity)[0];
+        var arguments = new List<RuntimeArgument>
+        {
+            new RuntimeArgument("argName", typeof(string), ArgumentDirection.In, true, new(), property, activity)
+        };
+
+        IList<ValidationError> errors = null;
+        ValidateArguments(activity, new OverloadGroupEquivalenceInfo(), new Dictionary<string, List<RuntimeArgument>>(), arguments, new Dictionary<string, object>(), ref errors);
+
+        errors.Count.ShouldBe(1);
+        var error = errors.First();
+
+        error.PropertyName.ShouldBe(arguments.First().Name);
+        error.Message.Contains(property.DisplayName).ShouldBeTrue();
+        error.Message.Contains(arguments.First().Name).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ValidateArguments_DisplayNameNotAvailable()
+    {
+        var activity = new Sequence();
+        var arguments = new List<RuntimeArgument>
+        {
+            new RuntimeArgument("argName", typeof(string), ArgumentDirection.In)
+        };
+
+        IList<ValidationError> errors = null;
+        ValidateArguments(activity, new OverloadGroupEquivalenceInfo(), new Dictionary<string, List<RuntimeArgument>>(), arguments, new Dictionary<string, object>(), ref errors);
+
+        errors.Count.ShouldBe(1);
+        var error = errors.First();
+
+        error.PropertyName.ShouldBe(arguments.First().Name);
+        error.Message.Contains(arguments.First().Name).ShouldBeTrue();
+    }
+}
+

--- a/src/UiPath.Workflow.Runtime/RuntimeArgument.cs
+++ b/src/UiPath.Workflow.Runtime/RuntimeArgument.cs
@@ -78,6 +78,8 @@ public sealed class RuntimeArgument : LocationReference
 
     public ArgumentDirection Direction { get; private set; }
 
+    public string DisplayName => _bindingProperty?.DisplayName ?? Name;
+
     public bool IsRequired { get; private set; }
 
     public ReadOnlyCollection<string> OverloadGroupNames

--- a/src/UiPath.Workflow.Runtime/RuntimeArgument.cs
+++ b/src/UiPath.Workflow.Runtime/RuntimeArgument.cs
@@ -78,7 +78,7 @@ public sealed class RuntimeArgument : LocationReference
 
     public ArgumentDirection Direction { get; private set; }
 
-    public string DisplayName => _bindingProperty?.DisplayName ?? Name;
+    internal string DisplayName => _bindingProperty?.DisplayName ?? Name;
 
     public bool IsRequired { get; private set; }
 

--- a/src/UiPath.Workflow.Runtime/UiPath.Workflow.Runtime.csproj
+++ b/src/UiPath.Workflow.Runtime/UiPath.Workflow.Runtime.csproj
@@ -26,7 +26,7 @@
 	<ProjectCapability Include="ConfigurableFileNesting" />
 	<ProjectCapability Include="ConfigurableFileNestingFeatureEnabled" />
   </ItemGroup>
-  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences" Condition="$(Configuration)=='Release'">
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
       <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
     </ItemGroup>

--- a/src/UiPath.Workflow.Runtime/UiPath.Workflow.Runtime.csproj
+++ b/src/UiPath.Workflow.Runtime/UiPath.Workflow.Runtime.csproj
@@ -26,7 +26,7 @@
 	<ProjectCapability Include="ConfigurableFileNesting" />
 	<ProjectCapability Include="ConfigurableFileNestingFeatureEnabled" />
   </ItemGroup>
-  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences" Condition="$(Configuration)=='Release'">
     <ItemGroup>
       <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
     </ItemGroup>

--- a/src/UiPath.Workflow.Runtime/Validation/ValidationHelper.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ValidationHelper.cs
@@ -25,7 +25,7 @@ internal static class ValidationHelper
             {
                 if (CheckIfArgumentIsNotBound(argument, inputs))
                 {
-                    ActivityUtilities.Add(ref validationErrors, new ValidationError(SR.RequiredArgumentValueNotSupplied(argument.Name), false, argument.Name, activity));
+                    ActivityUtilities.Add(ref validationErrors, new ValidationError(SR.RequiredArgumentValueNotSupplied(argument.DisplayName), false, argument.Name, activity));
                 }
             }
         }


### PR DESCRIPTION
https://uipath.atlassian.net/browse/STUD-68550

Connections in libraries feature is generating properties with names, which we do not want to display during validation.
We want to use display names, which we set during compilation, hence this change.