### PR TITLE
Pack System.Xaml also in debug

### DIFF
--- a/src/UiPath.Workflow.Runtime/UiPath.Workflow.Runtime.csproj
+++ b/src/UiPath.Workflow.Runtime/UiPath.Workflow.Runtime.csproj
@@ -26,7 +26,7 @@
 	<ProjectCapability Include="ConfigurableFileNesting" />
 	<ProjectCapability Include="ConfigurableFileNestingFeatureEnabled" />
   </ItemGroup>
-  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences" Condition="$(Configuration)=='Release'">
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
       <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
     </ItemGroup>


### PR DESCRIPTION
I dont know why it was packed only in Release, 
I lost an hour trying to figure out what is wrong when building Studio with a local version of CoreWF.

When using a locally built CoreWF package, Studio build gives a whole lot of strange errors because `System.Xaml.dll` is missing from net6 lib in package