### PR TITLE
Handle return type of 'null' expressions

### DIFF
--- a/src/UiPath.Workflow/Microsoft/CSharp/CSharpExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/CSharpExpressionCompiler.cs
@@ -33,7 +33,9 @@ internal sealed class CSharpExpressionCompiler : ExpressionCompiler
 
         var para = allNodes.First(n => n.GetType() == typeof(ParenthesizedLambdaExpressionSyntax));
         var node = allNodes.Skip(allNodes.IndexOf(para) + 1).OfType<ExpressionSyntax>().First();
-        var typeSymbol = semanticModel.GetTypeInfo(node).Type;
+        var typeInfo = semanticModel.GetTypeInfo(node);
+        var typeSymbol = typeInfo.Type ?? typeInfo.ConvertedType;
+
         return GetSystemType(typeSymbol, GetAssemblyForType(typeSymbol));
     }
 

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
@@ -24,10 +24,10 @@ internal sealed class VisualBasicExpressionCompiler : ExpressionCompiler
 
         var para = allNodes.First(n => n.GetType() == typeof(SingleLineLambdaExpressionSyntax));
         var node = allNodes.Skip(allNodes.IndexOf(para) + 1).OfType<ExpressionSyntax>().First();
+        var typeInfo = semanticModel.GetTypeInfo(node);
+        var typeSymbol = typeInfo.Type ?? typeInfo.ConvertedType;
 
-        var typeInfo = semanticModel.GetTypeInfo(node).Type;
-
-        return GetSystemType(typeInfo, GetAssemblyForType(typeInfo));
+        return GetSystemType(typeSymbol, GetAssemblyForType(typeSymbol));
     }
 
     protected override Compilation GetCompilation(IReadOnlyCollection<AssemblyReference> assemblies, IReadOnlyCollection<string> namespaces)


### PR DESCRIPTION
When a precompiled value is created, determining the `ReturnType` of an expression may throw an exception for certain values like `null` and `() => null` because there needs to be an implicit cast on the `SemanticModel` to figure out the type. In these scenarios, the `Type` property will be null and we should fallback to the `ConvertedType` [property](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.typeinfo.convertedtype?view=roslyn-dotnet-4.7.0#microsoft-codeanalysis-typeinfo-convertedtype) as this one is populated when it cannot be inferred without casting. 