### PR TITLE
process locations jit

### DIFF
--- a/src/UiPath.Workflow.Runtime/Expressions/CompiledExpressionInvoker.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/CompiledExpressionInvoker.cs
@@ -212,6 +212,8 @@ public class CompiledExpressionInvoker
 
     private void ProcessLocationReferences()
     {
+        _locationsInitialized = true;
+
         Stack<LocationReferenceEnvironment> environments = new();
         //
         // Build list of location by enumerating environments
@@ -258,8 +260,6 @@ public class CompiledExpressionInvoker
                 CreateRequiredArguments(requiredLocationNames);
             }
         }
-
-        _locationsInitialized = true;
     }
 
     private bool TryGetCompiledExpressionRootAtDesignTime(Activity expression, Activity target, out ICompiledExpressionRoot compiledExpressionRoot, out int exprId)


### PR DESCRIPTION
Make CompiledExpressionInvoker.ProcessLocationReferences lazy, only when validating.

There's a project (from a client) with 1400 global constants. Because all the global constants (and vars) are added into a global scope for data manager, and because you can theoretically (from a WF point of view) use any other variable in a variable, there's lots of LocationReference instances being created, each with associated state (e.g. autogenerated args). Each of the 1400 constants has location references to the other 1399 constants. 
This causes a lot of memory pressure (non leak). Project from the issue (the actual attachment is in the issue clone) uses around 3 GB of after opening and waiting for a while.

With the fix, on my machine, it climbs to about 1.2 GB before going back down to about 600MB.

This will be followed by a PR in studio which uses the ForceExpressionCache when validating the data manager global scope sequence.i

Studio PR: https://github.com/UiPath/Studio/pull/19913

https://uipath.atlassian.net/browse/STUD-70469