### PR TITLE
use dedicated flag for skipping calculation of location references

### DIFF
--- a/src/UiPath.Workflow.Runtime/ActivityLocationReferenceEnvironment.cs
+++ b/src/UiPath.Workflow.Runtime/ActivityLocationReferenceEnvironment.cs
@@ -24,6 +24,7 @@ internal sealed class ActivityLocationReferenceEnvironment : LocationReferenceEn
         {
             CompileExpressions = parent.CompileExpressions;
             IsValidating = parent.IsValidating;
+            SkipCalculatingLocationReferences = parent.SkipCalculatingLocationReferences;
             InternalRoot = parent.Root;
             Extensions = parent.Extensions;
         }

--- a/src/UiPath.Workflow.Runtime/Expressions/CompiledExpressionInvoker.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/CompiledExpressionInvoker.cs
@@ -41,7 +41,7 @@ public class CompiledExpressionInvoker
 
         _metadataRoot = metadata.Environment.Root;
 
-        if (!metadata.Environment.IsValidating)
+        if (!metadata.Environment.SkipCalculatingLocationReferences)
         {
             ProcessLocationReferences();
         }

--- a/src/UiPath.Workflow.Runtime/LocationReferenceEnvironment.cs
+++ b/src/UiPath.Workflow.Runtime/LocationReferenceEnvironment.cs
@@ -16,6 +16,11 @@ public abstract class LocationReferenceEnvironment
     /// </summary>
     internal bool IsValidating { get; set; }
 
+    /// <summary>
+    /// True if we want to skip calculating location references. This is useful if we are validating expressions which don't depend on other expressions.
+    /// </summary>
+    internal bool SkipCalculatingLocationReferences { get; set; } = false;
+
     internal EnvironmentExtensions Extensions { get; set; }
 
     public abstract Activity Root { get; }

--- a/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
@@ -431,6 +431,7 @@ public static class ActivityValidationServices
             _rootToValidate = toValidate;
             _environment = settings.Environment ?? new ActivityLocationReferenceEnvironment();
             _environment.IsValidating = !settings.ForceExpressionCache;
+            _environment.SkipCalculatingLocationReferences = settings.SkipCalculatingLocationReferences;
             if (settings.SkipExpressionCompilation)
             {
                 _environment.CompileExpressions = true;

--- a/src/UiPath.Workflow.Runtime/Validation/ValidationSettings.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ValidationSettings.cs
@@ -81,4 +81,9 @@ public class ValidationSettings
     /// Defaulting to true until validation path is proven.
     /// </remarks>
     public bool ForceExpressionCache { get; set; } = true;
+
+    /// <summary>
+    /// True if we want to skip calculating location references. This is useful if we are validating expressions which don't depend on other expressions.
+    /// </summary>
+    public bool SkipCalculatingLocationReferences { get; set; } = false;
 }


### PR DESCRIPTION
Use a dedicated flag to skip calculating location references, instead of the existing IsValidating flag. Reason is the scenario from the below issue.

This new flag is only set to true for data manager global scope (where one global variable cannot reference another one (and same goes for global constants)).

I've retested the large client project, and the memory pressure fix for it remains in place (once studio will set the new flag to true for data manager).


https://uipath.atlassian.net/browse/STUD-70876