### PR TITLE
do not require same sync context for compilation

### DIFF
--- a/src/UiPath.Workflow/Activities/DesignerHelperImpl.cs
+++ b/src/UiPath.Workflow/Activities/DesignerHelperImpl.cs
@@ -385,7 +385,7 @@ internal abstract class DesignerHelperImpl
 
         // execute compiler
         var compilation = Compiler.Compile(expressionText, isLocation, targetType ?? typeof(object), namespaces.ToList(), referencedAssemblies.ToList(), environment);
-        var diagnostics = await compilation.WithAnalyzers(_usedTypesAnalizerList).GetAllDiagnosticsAsync();
+        var diagnostics = await compilation.WithAnalyzers(_usedTypesAnalizerList).GetAllDiagnosticsAsync().ConfigureAwait(false);
 
         if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
         {


### PR DESCRIPTION
The deadlock is caused by:
1. Thread A uses the model item in whatever way, so it locks it
2. There's a Task.Run with VisualBasicDesignerHelper.CreatePrecompiledValueAsync().Result in WorkflowDesigner => Thread B
3. Thread B will eventually do FindVariable, which enumerates the model item, so tries to lock again => DEADLOCK

This PR will be followed by another PR in WorkflowDesigner, which does not use Task.Run anymore, for this compilation, so the flow will be:
1. Thread A locks the model item
2. Thread A does VisualBasicDesignerHelper.CreatePrecompiledValueAsync().Result
3. Thread A does FindVariable (it will be able to recursively acquire the lock)
4. Thread A does await GetAllDiagnosticsAsync(), which needs ConfigureAwait(false) (as the thread will be blocked at the earlier .Result now)

https://uipath.atlassian.net/browse/STUD-70986