### PR TITLE
Fix array of array

### DIFF
--- a/src/Test/TestCases.Workflows/XamlTests.cs
+++ b/src/Test/TestCases.Workflows/XamlTests.cs
@@ -276,6 +276,8 @@ namespace TestCases.Workflows
         [InlineData(typeof(Func<string>), "Function() (1 + 1)", true)]
         [InlineData(typeof(Func<string>), "Function() (Nothing)", false)]
         [InlineData(typeof(Func<string>), "Function() (\"test\")", false)]
+        [InlineData(typeof(string[][]), "Nothing", false)]
+        [InlineData(typeof(string[][][][]), "Nothing", false)]
         public async Task VB_CreatePrecompiedValueAsync_CorrectReturnType(Type targetType, string expressionText, bool shouldExpectError)
         {
             var location = new ActivityLocationReferenceEnvironment();
@@ -305,6 +307,8 @@ namespace TestCases.Workflows
         [InlineData(typeof(Func<string>), "() => null", false)]
         [InlineData(typeof(Func<string>), "() => 1 + 1", true)]
         [InlineData(typeof(Func<string>), "() => \"test\"", false)]
+        [InlineData(typeof(string[][]), "default", false)]
+        [InlineData(typeof(string[][][][]), "default", false)]
         public async Task CS_CreatePrecompiedValueAsync_CorrectReturnType(Type targetType, string expressionText, bool shouldExpectError)
         {
             var location = new ActivityLocationReferenceEnvironment();

--- a/src/UiPath.Workflow/Activities/ExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ExpressionCompiler.cs
@@ -24,7 +24,7 @@ namespace System.Activities
         {
             if (type is IArrayTypeSymbol arrayTypeSymbol)
             {
-                return AssemblyReference.GetAssembly(new AssemblyName(arrayTypeSymbol.ElementType.ContainingAssembly.Name));
+                return AssemblyReference.GetAssembly(new AssemblyName(GetAssemblyForType(arrayTypeSymbol.ElementType).GetName().Name));
             }
             else
             {


### PR DESCRIPTION
`arrayTypeSymbol.ElementType.ContainingAssembly` is null if elementType is an array of a type, so we just call ourselves recursively till we reach the actual type that is not an array