### PR TITLE
Add new extension for cases where a required extension is missing ROBO-4220

### DIFF
--- a/src/Test/TestCases.Runtime/MissingRequiredExtensionTests.cs
+++ b/src/Test/TestCases.Runtime/MissingRequiredExtensionTests.cs
@@ -29,8 +29,9 @@ namespace TestCases.Runtime
             }
             else
             {
-                exception.ShouldBeOfType<ExtensionRequiredException>();
-                ((ExtensionRequiredException)exception).RequiredExtensionType.ShouldBe(typeof(StringBuilder));
+                exception.ShouldBeOfType<ValidationException>();
+                exception.InnerException.ShouldBeOfType<ExtensionRequiredException>();
+                ((ExtensionRequiredException)exception.InnerException).RequiredExtensionType.ShouldBe(typeof(StringBuilder));
             }
         }
 

--- a/src/Test/TestCases.Runtime/MissingRequiredExtensionTests.cs
+++ b/src/Test/TestCases.Runtime/MissingRequiredExtensionTests.cs
@@ -5,7 +5,6 @@ using Shouldly;
 using System.Activities;
 using System.Activities.Statements;
 using System.Text;
-using Test.Common.TestObjects.Activities;
 using Xunit;
 
 namespace TestCases.Runtime
@@ -23,6 +22,18 @@ namespace TestCases.Runtime
 
             var ex = Assert.Throws<ExtensionRequiredException>(instance.Run);
             ex.RequiredExtensionType.ShouldBe(typeof(StringBuilder));
+        }
+
+        private class MissingRequiredExtension<T> : NativeActivity
+        {
+            protected override void CacheMetadata(NativeActivityMetadata metadata)
+            {
+                metadata.RequireExtension(typeof(T));
+            }
+
+            protected override void Execute(NativeActivityContext context)
+            {
+            }
         }
     }
 }

--- a/src/Test/TestCases.Runtime/MissingRequiredExtensionTests.cs
+++ b/src/Test/TestCases.Runtime/MissingRequiredExtensionTests.cs
@@ -1,0 +1,28 @@
+﻿// This file is part of Core WF which is licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+using Shouldly;
+using System.Activities;
+using System.Activities.Statements;
+using System.Text;
+using Test.Common.TestObjects.Activities;
+using Xunit;
+
+namespace TestCases.Runtime
+{
+    public class MissingRequiredExtensionTests
+    {
+        [Fact]
+        public void RunningActivityWithUnregisteredRequiredExtensionShouldThrow()
+        {
+            var sequence = new Sequence
+            {
+                Activities = { new MissingRequiredExtension<StringBuilder>() }
+            };
+            WorkflowApplication instance = new WorkflowApplication(sequence);
+
+            var ex = Assert.Throws<ExtensionRequiredException>(instance.Run);
+            ex.RequiredExtensionType.ShouldBe(typeof(StringBuilder));
+        }
+    }
+}

--- a/src/Test/TestCases.Runtime/MissingRequiredExtensionTests.cs
+++ b/src/Test/TestCases.Runtime/MissingRequiredExtensionTests.cs
@@ -31,7 +31,8 @@ namespace TestCases.Runtime
             {
                 exception.ShouldBeOfType<ValidationException>();
                 exception.InnerException.ShouldBeOfType<ExtensionRequiredException>();
-                ((ExtensionRequiredException)exception.InnerException).RequiredExtensionType.ShouldBe(typeof(StringBuilder));
+                var expectedName = typeof(StringBuilder).FullName;
+                ((ExtensionRequiredException)exception.InnerException).RequiredExtensionTypeFullName.ShouldBe(expectedName);
             }
         }
 

--- a/src/Test/TestObjects/Activities/TestReadLine.cs
+++ b/src/Test/TestObjects/Activities/TestReadLine.cs
@@ -229,4 +229,16 @@ namespace Test.Common.TestObjects.Activities
             traceGroup.Steps.Add(new UserTrace(WaitReadLine<T>.AfterWait));
         }
     }
+
+    public class MissingRequiredExtension<T> : NativeActivity
+    {
+        protected override void CacheMetadata(NativeActivityMetadata metadata)
+        {
+            metadata.RequireExtension(typeof(T));
+        }
+
+        protected override void Execute(NativeActivityContext context)
+        {
+        }
+    }
 }

--- a/src/Test/TestObjects/Activities/TestReadLine.cs
+++ b/src/Test/TestObjects/Activities/TestReadLine.cs
@@ -229,16 +229,4 @@ namespace Test.Common.TestObjects.Activities
             traceGroup.Steps.Add(new UserTrace(WaitReadLine<T>.AfterWait));
         }
     }
-
-    public class MissingRequiredExtension<T> : NativeActivity
-    {
-        protected override void CacheMetadata(NativeActivityMetadata metadata)
-        {
-            metadata.RequireExtension(typeof(T));
-        }
-
-        protected override void Execute(NativeActivityContext context)
-        {
-        }
-    }
 }

--- a/src/UiPath.Workflow.Runtime/ExtensionRequiredException.cs
+++ b/src/UiPath.Workflow.Runtime/ExtensionRequiredException.cs
@@ -1,0 +1,15 @@
+﻿// This file is part of Core WF which is licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+namespace System.Activities;
+
+public class ExtensionRequiredException : ValidationException
+{
+    public Type RequiredExtensionType { get; private set; }
+
+    public ExtensionRequiredException(Type requiredType)
+        : base(SR.RequiredExtensionTypeNotFound(requiredType.ToString()))
+    {
+        RequiredExtensionType = requiredType;
+    }
+}

--- a/src/UiPath.Workflow.Runtime/ExtensionRequiredException.cs
+++ b/src/UiPath.Workflow.Runtime/ExtensionRequiredException.cs
@@ -8,35 +8,28 @@ public class ExtensionRequiredException : Exception
 {
     private const string RequiredExtensionTypeName = "requiredExtensionType";
 
-    public string RequiredExtensionTypeFullName { get; }
+    public string RequiredExtensionTypeFullName => Data[RequiredExtensionTypeName] as string;
 
     public ExtensionRequiredException(Type requiredType)
         : base()
     {
-        RequiredExtensionTypeFullName = requiredType.FullName;
+        Data.Add(RequiredExtensionTypeName, requiredType.FullName);
     }
 
     public ExtensionRequiredException(Type requiredType, string message)
         : base(message)
     {
-        RequiredExtensionTypeFullName = requiredType.FullName;
+        Data.Add(RequiredExtensionTypeName, requiredType.FullName);
     }
 
     public ExtensionRequiredException(Type requiredType, string message, Exception innerException)
         : base(message, innerException)
     {
-        RequiredExtensionTypeFullName = requiredType.FullName;
+        Data.Add(RequiredExtensionTypeName, requiredType.FullName);
     }
 
     public ExtensionRequiredException(SerializationInfo info, StreamingContext context)
         : base(info, context)
     {
-        RequiredExtensionTypeFullName = info.GetString(RequiredExtensionTypeName);
-    }
-
-    public override void GetObjectData(SerializationInfo info, StreamingContext context)
-    {
-        base.GetObjectData(info, context);
-        info.AddValue(RequiredExtensionTypeName, RequiredExtensionTypeFullName, typeof(string));
     }
 }

--- a/src/UiPath.Workflow.Runtime/ExtensionRequiredException.cs
+++ b/src/UiPath.Workflow.Runtime/ExtensionRequiredException.cs
@@ -6,29 +6,37 @@ namespace System.Activities;
 [Serializable]
 public class ExtensionRequiredException : Exception
 {
-    public Type RequiredExtensionType { get; }
+    private const string RequiredExtensionTypeName = "requiredExtensionType";
+
+    public string RequiredExtensionTypeFullName { get; }
 
     public ExtensionRequiredException(Type requiredType)
         : base()
     {
-        RequiredExtensionType = requiredType;
+        RequiredExtensionTypeFullName = requiredType.FullName;
     }
 
     public ExtensionRequiredException(Type requiredType, string message)
         : base(message)
     {
-        RequiredExtensionType = requiredType;
+        RequiredExtensionTypeFullName = requiredType.FullName;
     }
 
     public ExtensionRequiredException(Type requiredType, string message, Exception innerException)
         : base(message, innerException)
     {
-        RequiredExtensionType = requiredType;
+        RequiredExtensionTypeFullName = requiredType.FullName;
     }
 
-    public ExtensionRequiredException(Type requiredType, SerializationInfo info, StreamingContext context)
+    public ExtensionRequiredException(SerializationInfo info, StreamingContext context)
         : base(info, context)
     {
-        RequiredExtensionType = requiredType;
+        RequiredExtensionTypeFullName = info.GetString(RequiredExtensionTypeName);
+    }
+
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        base.GetObjectData(info, context);
+        info.AddValue(RequiredExtensionTypeName, RequiredExtensionTypeFullName, typeof(string));
     }
 }

--- a/src/UiPath.Workflow.Runtime/ExtensionRequiredException.cs
+++ b/src/UiPath.Workflow.Runtime/ExtensionRequiredException.cs
@@ -3,12 +3,31 @@
 
 namespace System.Activities;
 
-public class ExtensionRequiredException : ValidationException
+[Serializable]
+public class ExtensionRequiredException : Exception
 {
-    public Type RequiredExtensionType { get; private set; }
+    public Type RequiredExtensionType { get; }
 
     public ExtensionRequiredException(Type requiredType)
-        : base(SR.RequiredExtensionTypeNotFound(requiredType.ToString()))
+        : base()
+    {
+        RequiredExtensionType = requiredType;
+    }
+
+    public ExtensionRequiredException(Type requiredType, string message)
+        : base(message)
+    {
+        RequiredExtensionType = requiredType;
+    }
+
+    public ExtensionRequiredException(Type requiredType, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        RequiredExtensionType = requiredType;
+    }
+
+    public ExtensionRequiredException(Type requiredType, SerializationInfo info, StreamingContext context)
+        : base(info, context)
     {
         RequiredExtensionType = requiredType;
     }

--- a/src/UiPath.Workflow.Runtime/Hosting/WorkflowInstanceExtensionCollection.cs
+++ b/src/UiPath.Workflow.Runtime/Hosting/WorkflowInstanceExtensionCollection.cs
@@ -118,7 +118,9 @@ internal class WorkflowInstanceExtensionCollection
                 {
                     if (!TypeHelper.ContainsCompatibleType(allExtensionTypes, requiredType))
                     {
-                        throw FxTrace.Exception.AsError(new ExtensionRequiredException(requiredType));
+                        throw FxTrace.Exception.AsError(new ValidationException(
+                            SR.RequiredExtensionTypeNotFound(requiredType.ToString()),
+                            new ExtensionRequiredException(requiredType)));
                     }
                 }
             }

--- a/src/UiPath.Workflow.Runtime/Hosting/WorkflowInstanceExtensionCollection.cs
+++ b/src/UiPath.Workflow.Runtime/Hosting/WorkflowInstanceExtensionCollection.cs
@@ -118,7 +118,7 @@ internal class WorkflowInstanceExtensionCollection
                 {
                     if (!TypeHelper.ContainsCompatibleType(allExtensionTypes, requiredType))
                     {
-                        throw FxTrace.Exception.AsError(new ValidationException(SR.RequiredExtensionTypeNotFound(requiredType.ToString())));
+                        throw FxTrace.Exception.AsError(new ExtensionRequiredException(requiredType));
                     }
                 }
             }


### PR DESCRIPTION
# Description 
In case of a missing required extensions we throw a ValidationException. Users might want to handle those cases explicitly and they would need to know the type of the missing extension.

To achieve this, we added ExtensionRequiredException which inherits ValidationException and has a single property RequiredExtensionType.

# Jira
https://uipath.atlassian.net/browse/ROBO-4220