### PR TITLE
Guard against NRE when working with anonymus types [STUD-73041]

### DIFF
--- a/src/UiPath.Workflow/Activities/ExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ExpressionCompiler.cs
@@ -43,11 +43,16 @@ namespace System.Activities
             {
                 if (namedTypeSymbol.IsGenericType)
                 {
-                    return assembly.GetType($"{namedTypeSymbol.ContainingNamespace}.{namedTypeSymbol.MetadataName}").MakeGenericType(namedTypeSymbol.TypeArguments.Select(t=> GetSystemType(t, GetAssemblyForType(t))).ToArray());
+                    return assembly.GetType($"{namedTypeSymbol.ContainingNamespace.ToDisplayString()}.{namedTypeSymbol.MetadataName}").MakeGenericType(namedTypeSymbol.TypeArguments.Select(t => GetSystemType(t, GetAssemblyForType(t))).ToArray());
+                }
+
+                if (namedTypeSymbol.IsAnonymousType)
+                {
+                    return typeof(object);
                 }
             }
 
-            return assembly.GetType($"{typeSymbol.ContainingNamespace}.{typeSymbol.MetadataName}");
+            return assembly.GetType($"{typeSymbol.ContainingNamespace.ToDisplayString()}.{typeSymbol.MetadataName}");
         }
 
         protected abstract Compilation GetCompilation(IReadOnlyCollection<AssemblyReference> assemblies, IReadOnlyCollection<string> namespaces);


### PR DESCRIPTION
`GetSystemType` method fails to determine the type for anonymous functions and throws a NRE. This PR guards against this scenario but ignores contents of anonymous types (same as previous implementation).

https://uipath.atlassian.net/browse/STUD-73041