### PR TITLE
robo-4382 Introduce option to opt-out of bookmark creation in Delay statement

### DIFF
--- a/src/Test/TestCases.Runtime/StatementsBehaviorExtensionTests.cs
+++ b/src/Test/TestCases.Runtime/StatementsBehaviorExtensionTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Activities;
+using System.Activities.Statements;
+using System.Threading;
+using Shouldly;
+using Test.Common.TestObjects.CustomActivities;
+using UiPath.Workflow.Runtime.Statements;
+using WorkflowApplicationTestExtensions.Persistence;
+using Xunit;
+
+namespace TestCases.Runtime
+{
+    public class StatementsBehaviorExtensionTests
+    {
+        /// <summary>
+        /// Tests that using StatementsBehaviorExtension extension with BlockingDelay = true, the Delay activity doesn't trigger PersistableIdle
+        /// </summary>
+        [Fact]
+        public static void TestBlockingDelayShouldNotPersist()
+        {
+            var testSequence = new Sequence()
+            {
+                Activities =
+            {
+                new Delay()
+                {
+                    Duration = TimeSpan.FromMilliseconds(100)
+                },
+            }
+            };
+            bool workflowIdleAndPersistable = false;
+            var completed = new ManualResetEvent(false);
+            WorkflowApplication workflowApplication = new WorkflowApplication(testSequence);
+            workflowApplication.InstanceStore = new MemoryInstanceStore();
+            workflowApplication.Extensions.Add(new StatementsBehaviorExtension { BlockingDelay = true });
+            workflowApplication.PersistableIdle = (_) => { workflowIdleAndPersistable = true; return PersistableIdleAction.None; };
+            workflowApplication.Completed = (_) => completed.Set();
+            workflowApplication.Run();
+            completed.WaitOne();
+            workflowIdleAndPersistable.ShouldBeFalse(); //there is no persistable idle
+        }
+
+        /// <summary>
+        /// Tests that without using StatementsBehaviorExtension extension, the Delay activity triggers PersistableIdle
+        /// </summary>
+        [Fact]
+        public static void TestNonBlockingDelayShouldPersist()
+        {
+            var testSequence = new Sequence()
+            {
+                Activities =
+            {
+                new Delay()
+                {
+                    Duration = TimeSpan.FromMilliseconds(100)
+                },
+            }
+            };
+            bool workflowIdleAndPersistable = false;
+            var completed = new ManualResetEvent(false);
+            WorkflowApplication workflowApplication = new WorkflowApplication(testSequence);
+            workflowApplication.InstanceStore = new MemoryInstanceStore();
+            workflowApplication.PersistableIdle = (_) => { workflowIdleAndPersistable = true; return PersistableIdleAction.None; };
+            workflowApplication.Completed = (_) => completed.Set();
+            workflowApplication.Run();
+            completed.WaitOne();
+            workflowIdleAndPersistable.ShouldBeTrue();
+        }
+
+        /// <summary>
+        /// Tests that having StatementsBehaviorExtension extension with BlockingDelay=true, the Delay activity blocks the 
+        /// PersistableIdle event from any other activity in the workflow, including parallel activities. 
+        /// </summary>
+        [Fact]
+        public static void TestParallelBlockingActivityShouldTriggerPersistAfterDelayFinishes()
+        {
+            var delayDuration = TimeSpan.FromMilliseconds(100);
+
+            var testSequence = new Sequence()
+            {
+                Activities =
+            {
+                new Parallel()
+                {
+                    Branches =
+                    {
+                        new Delay() { Duration = delayDuration  },
+                        new BlockingActivity("B")
+                    }
+                },
+            }
+            };
+            bool workflowIdleAndPersistable = false;
+            var completed = new ManualResetEvent(false);
+            var persistableIdleTriggered = new ManualResetEvent(false);
+
+            var sw = new System.Diagnostics.Stopwatch();
+
+            WorkflowApplication workflowApplication = new WorkflowApplication(testSequence);
+            workflowApplication.InstanceStore = new MemoryInstanceStore();
+            workflowApplication.Extensions.Add(new StatementsBehaviorExtension { BlockingDelay = true });
+
+
+            workflowApplication.PersistableIdle = (_) => {
+                //check if more than 100ms passed
+                sw.ElapsedMilliseconds.ShouldBeGreaterThan(delayDuration.Milliseconds);
+                workflowIdleAndPersistable = true;
+                persistableIdleTriggered.Set();
+                return PersistableIdleAction.None;
+            };
+            workflowApplication.Completed = (_) => completed.Set();
+            sw.Start();
+            workflowApplication.Run();
+            persistableIdleTriggered.WaitOne(); // Wait for PersistableIdle to trigger
+            workflowApplication.ResumeBookmark("B", null); //Resume the bookmark from the blocking activity
+            completed.WaitOne();
+            workflowIdleAndPersistable.ShouldBeTrue();
+        }
+    }
+}

--- a/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
+++ b/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
@@ -406,7 +406,7 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         };
         WorkflowApplicationTestExtensions.Persistence.FileInstanceStore jsonStore = new WorkflowApplicationTestExtensions.Persistence.FileInstanceStore(".\\~");
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
-        workflowRuntime.OnWorkflowIdle += (_, __) => throw new Exception("Should not idle");
+        workflowRuntime.OnWorkflowIdleAndPersistable += (_, __) => throw new Exception("Should not idle");
         workflowRuntime.OnWorkflowUnloaded += (_, __) => throw new Exception("Should not unload");
         workflowRuntime.ExecuteWorkflow();
         workflowRuntime.WaitForCompletion();
@@ -434,7 +434,7 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         };
         WorkflowApplicationTestExtensions.Persistence.FileInstanceStore jsonStore = new WorkflowApplicationTestExtensions.Persistence.FileInstanceStore(".\\~");
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
-        workflowRuntime.OnWorkflowIdle += (_, __) => throw new Exception("Should not idle");
+        workflowRuntime.OnWorkflowIdleAndPersistable += (_, __) => throw new Exception("Should not idle");
         workflowRuntime.OnWorkflowUnloaded += (_, __) => throw new Exception("Should not unload");
         workflowRuntime.ExecuteWorkflow();
         workflowRuntime.ResumeBookMark("B", null);

--- a/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
+++ b/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
@@ -377,7 +377,7 @@ public class WorflowInstanceResumeBookmarkAsyncTests
             {
                 new TestDelay()
                 {
-                    Duration = TimeSpan.FromMilliseconds(100)
+                    Duration = TimeSpan.FromMilliseconds(200)
                 },
             }
         };

--- a/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
+++ b/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
@@ -409,7 +409,7 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         WorkflowApplicationTestExtensions.Persistence.FileInstanceStore jsonStore = new WorkflowApplicationTestExtensions.Persistence.FileInstanceStore(".\\~");
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
         workflowRuntime.CreateWorkflow();
-        workflowRuntime.Extensions.Add(new WorkflowSettingsExtension { BlockingDelay = true });
+        workflowRuntime.Extensions.Add(new StatementsBehaviorExtension { BlockingDelay = true });
         workflowRuntime.OnWorkflowIdleAndPersistable += (_, __) => throw new Exception("Should not idle");
         workflowRuntime.OnWorkflowUnloaded += (_, __) => throw new Exception("Should not unload");
         workflowRuntime.ResumeWorkflow();
@@ -439,7 +439,7 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         WorkflowApplicationTestExtensions.Persistence.FileInstanceStore jsonStore = new WorkflowApplicationTestExtensions.Persistence.FileInstanceStore(".\\~");
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
         workflowRuntime.CreateWorkflow();
-        workflowRuntime.Extensions.Add(new WorkflowSettingsExtension { BlockingDelay = true });
+        workflowRuntime.Extensions.Add(new StatementsBehaviorExtension { BlockingDelay = true });
         workflowRuntime.OnWorkflowIdleAndPersistable += (_, __) => throw new Exception("Should not idle");
         workflowRuntime.OnWorkflowUnloaded += (_, __) => throw new Exception("Should not unload");
         workflowRuntime.ResumeWorkflow();

--- a/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
+++ b/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
@@ -384,8 +384,8 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         };
         WorkflowApplicationTestExtensions.Persistence.FileInstanceStore jsonStore = new WorkflowApplicationTestExtensions.Persistence.FileInstanceStore(".\\~");
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
+        workflowRuntime.OnWorkflowIdleAndPersistable += (_, __) => workflowRuntime.PersistWorkflow();
         workflowRuntime.ExecuteWorkflow();
-        workflowRuntime.PersistWorkflow();
         workflowRuntime.WaitForUnloaded();
         workflowRuntime.LoadWorkflow();
         workflowRuntime.ResumeWorkflow();

--- a/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
+++ b/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
@@ -385,7 +385,6 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
         workflowRuntime.ExecuteWorkflow();
         workflowRuntime.PersistWorkflow();
-        //workflowRuntime.WaitForCompletion();
         workflowRuntime.LoadWorkflow();
         workflowRuntime.ResumeWorkflow();
         workflowRuntime.WaitForCompletion(false);
@@ -407,13 +406,14 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         };
         WorkflowApplicationTestExtensions.Persistence.FileInstanceStore jsonStore = new WorkflowApplicationTestExtensions.Persistence.FileInstanceStore(".\\~");
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
+        workflowRuntime.OnWorkflowIdle += (_, __) => throw new Exception("Should not idle");
         workflowRuntime.OnWorkflowUnloaded += (_, __) => throw new Exception("Should not unload");
         workflowRuntime.ExecuteWorkflow();
         workflowRuntime.WaitForCompletion();
     }
 
     [Fact]
-    public static void TestBookmarkShouldNotUnloadWithParallelDelay()
+    public static void TestBookmarkWithParallelDelayShouldNotUnloadWorkflow()
     {
         var testSequence = new TestSequence()
         {
@@ -434,6 +434,7 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         };
         WorkflowApplicationTestExtensions.Persistence.FileInstanceStore jsonStore = new WorkflowApplicationTestExtensions.Persistence.FileInstanceStore(".\\~");
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
+        workflowRuntime.OnWorkflowIdle += (_, __) => throw new Exception("Should not idle");
         workflowRuntime.OnWorkflowUnloaded += (_, __) => throw new Exception("Should not unload");
         workflowRuntime.ExecuteWorkflow();
         workflowRuntime.ResumeBookMark("B", null);

--- a/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
+++ b/src/Test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
@@ -11,6 +11,7 @@ using Test.Common.TestObjects.Runtime;
 using Test.Common.TestObjects.Utilities;
 using Test.Common.TestObjects.Utilities.Validation;
 using TestCases.Runtime.Common.Activities;
+using UiPath.Workflow.Runtime.Statements;
 using WorkflowApplicationTestExtensions.Persistence;
 using Xunit;
 namespace TestCases.Runtime.WorkflowInstanceTest;
@@ -385,6 +386,7 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
         workflowRuntime.ExecuteWorkflow();
         workflowRuntime.PersistWorkflow();
+        workflowRuntime.WaitForUnloaded();
         workflowRuntime.LoadWorkflow();
         workflowRuntime.ResumeWorkflow();
         workflowRuntime.WaitForCompletion(false);
@@ -392,7 +394,7 @@ public class WorflowInstanceResumeBookmarkAsyncTests
 
 
     [Fact]
-    public static void TestDelayShouldNotUnload()
+    public static void TestBlockingDelayShouldNotUnload()
     {
         var testSequence = new TestSequence()
         {
@@ -406,9 +408,11 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         };
         WorkflowApplicationTestExtensions.Persistence.FileInstanceStore jsonStore = new WorkflowApplicationTestExtensions.Persistence.FileInstanceStore(".\\~");
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
+        workflowRuntime.CreateWorkflow();
+        workflowRuntime.Extensions.Add(new WorkflowSettingsExtension { BlockingDelay = true });
         workflowRuntime.OnWorkflowIdleAndPersistable += (_, __) => throw new Exception("Should not idle");
         workflowRuntime.OnWorkflowUnloaded += (_, __) => throw new Exception("Should not unload");
-        workflowRuntime.ExecuteWorkflow();
+        workflowRuntime.ResumeWorkflow();
         workflowRuntime.WaitForCompletion();
     }
 
@@ -434,9 +438,11 @@ public class WorflowInstanceResumeBookmarkAsyncTests
         };
         WorkflowApplicationTestExtensions.Persistence.FileInstanceStore jsonStore = new WorkflowApplicationTestExtensions.Persistence.FileInstanceStore(".\\~");
         TestWorkflowRuntime workflowRuntime = TestRuntime.CreateTestWorkflowRuntime(testSequence, null, jsonStore, PersistableIdleAction.Unload);
+        workflowRuntime.CreateWorkflow();
+        workflowRuntime.Extensions.Add(new WorkflowSettingsExtension { BlockingDelay = true });
         workflowRuntime.OnWorkflowIdleAndPersistable += (_, __) => throw new Exception("Should not idle");
         workflowRuntime.OnWorkflowUnloaded += (_, __) => throw new Exception("Should not unload");
-        workflowRuntime.ExecuteWorkflow();
+        workflowRuntime.ResumeWorkflow();
         workflowRuntime.ResumeBookMark("B", null);
         workflowRuntime.WaitForCompletion();
     }

--- a/src/UiPath.Workflow.Runtime/Statements/Delay.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/Delay.cs
@@ -97,6 +97,6 @@ public sealed class Delay : NativeActivity
 
     private bool HasBlockingDelay(NativeActivityContext context)
     {
-        return context.GetExtension<WorkflowSettingsExtension>()?.BlockingDelay == true;
+        return context.GetExtension<StatementsBehaviorExtension>()?.BlockingDelay == true;
     }
 }

--- a/src/UiPath.Workflow.Runtime/Statements/Delay.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/Delay.cs
@@ -57,7 +57,7 @@ public sealed class Delay : NativeActivity
 
         _noPersistHandle.Get(context).Enter(context);
 
-        Bookmark bookmark = context.CreateBookmark(OnTimerFired);
+        Bookmark bookmark = context.CreateBookmark();
         timerExtension.RegisterTimer(duration, bookmark);
         _timerBookmark.Set(context, bookmark);
     }
@@ -83,16 +83,6 @@ public sealed class Delay : NativeActivity
             timerExtension.CancelTimer(timerBookmark);
         }
         base.Abort(context);
-    }
-
-    private void OnTimerFired(NativeActivityContext context, Bookmark bookmark, object value)
-    {
-        // Timer has fired, now we can exit the NoPersistHandle to allow persistence again
-        NoPersistHandle handle = _noPersistHandle.Get(context);
-        if (handle != null)
-        {
-            handle.Exit(context);
-        }
     }
 
     private TimerExtension GetTimerExtension(ActivityContext context)

--- a/src/UiPath.Workflow.Runtime/Statements/Delay.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/Delay.cs
@@ -71,9 +71,6 @@ public sealed class Delay : NativeActivity
         timerExtension.CancelTimer(timerBookmark);
         context.RemoveBookmark(timerBookmark);
         context.MarkCanceled();
-
-        if (HasBlockingDelay(context))
-            _noPersistHandle.Get(context).Exit(context);
     }
 
     protected override void Abort(NativeActivityAbortContext context)

--- a/src/UiPath.Workflow.Runtime/Statements/Delay.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/Delay.cs
@@ -4,6 +4,7 @@
 using System.Activities.Runtime;
 using System.Collections.ObjectModel;
 using System.Windows.Markup;
+using UiPath.Workflow.Runtime.Statements;
 
 namespace System.Activities.Statements;
 
@@ -55,7 +56,8 @@ public sealed class Delay : NativeActivity
 
         TimerExtension timerExtension = GetTimerExtension(context);
 
-        _noPersistHandle.Get(context).Enter(context);
+        if (HasBlockingDelay(context))
+            _noPersistHandle.Get(context).Enter(context);
 
         Bookmark bookmark = context.CreateBookmark();
         timerExtension.RegisterTimer(duration, bookmark);
@@ -70,7 +72,8 @@ public sealed class Delay : NativeActivity
         context.RemoveBookmark(timerBookmark);
         context.MarkCanceled();
 
-        _noPersistHandle.Get(context).Exit(context);
+        if (HasBlockingDelay(context))
+            _noPersistHandle.Get(context).Exit(context);
     }
 
     protected override void Abort(NativeActivityAbortContext context)
@@ -90,5 +93,10 @@ public sealed class Delay : NativeActivity
         TimerExtension timerExtension = context.GetExtension<TimerExtension>();
         Fx.Assert(timerExtension != null, "TimerExtension must exist.");
         return timerExtension;
+    }
+
+    private bool HasBlockingDelay(NativeActivityContext context)
+    {
+        return context.GetExtension<WorkflowSettingsExtension>()?.BlockingDelay == true;
     }
 }

--- a/src/UiPath.Workflow.Runtime/Statements/StatementsBehaviorExtension.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/StatementsBehaviorExtension.cs
@@ -6,7 +6,10 @@ using System.Threading.Tasks;
 
 namespace UiPath.Workflow.Runtime.Statements
 {
-    public class WorkflowSettingsExtension
+    /// <summary>
+    /// An extension that configures/changes the behavior of some statements like Delay.
+    /// </summary>
+    public class StatementsBehaviorExtension
     {
         /// <summary>
         /// When true, the delay activity will block the persistance idle event until the delay is over, 

--- a/src/UiPath.Workflow.Runtime/Statements/WorkflowSettingsExtension.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/WorkflowSettingsExtension.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UiPath.Workflow.Runtime.Statements
+{
+    public class WorkflowSettingsExtension
+    {
+        /// <summary>
+        /// When true, the delay activity will block the persistance idle event until the delay is over, 
+        /// preventing the workflow from being persisted.
+        /// </summary>
+        public bool BlockingDelay { get; set; } = false;
+    }
+}


### PR DESCRIPTION
Current behaviour: the job never gets resumed from Orchestrator when using Delay.

The delay activity should block persistence triggering. The workflow cannot be persisted/unloaded while there is a active delay activity. 