### PR TITLE
STUD-73749 Project is closed due to internal error that is triggered when attempting to open a xaml file from Errors panel

### DIFF
--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -70,7 +70,6 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
             CompilerHelper.CreateExpressionCode(types, names, expressionToCompile.Code))));
 
         var collectibleAlc = new AssemblyLoadContext("ScriptingJit" + Guid.NewGuid(), true);
-        collectibleAlc.Resolving += CollectibleAlc_Resolving;
         using var scope = collectibleAlc.EnterContextualReflection();
 
         var results = TryBuild();
@@ -99,17 +98,6 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
             }
 
         }
-    }
-
-
-
-    private Assembly CollectibleAlc_Resolving(AssemblyLoadContext loadContext, AssemblyName assemblyName)
-    {
-        var assembly = AppDomain.CurrentDomain.GetAssemblies().LastOrDefault(a => a.FullName == assemblyName.FullName);
-        if (assembly != null)
-            return assembly;
-
-        return loadContext.LoadFromAssemblyName(assemblyName);
     }
 
     public IEnumerable<string> GetIdentifiers(SyntaxTree syntaxTree)


### PR DESCRIPTION
ScriptingJitCompiler compiles expressions into a collectible AssemblyLoadContext. This ALC has a resolving event which is triggered when an assembly needed by a type is not found. 
Sometimes (rarely reproducible) the expression build process triggers events in Studio that execute under the collectible ALC, and when a type that does not exists is resolved, the Resolving event is triggered. 
Our implementation of the Resolving event is wrong. It is searching for assemblies in our current domain and if it can't find them it calls LoadFromAssemblyName. But LoadFromAssemblyName was already called and it triggered the Resolving event. This ends up in a loop that eventually triggers a StackOverflow exception.

https://uipath.atlassian.net/browse/STUD-73749
