### PR TITLE
STUD-74608-Improve-validation

### DIFF
--- a/src/Test/TestCases.Workflows/ValidationOptimizationTests.cs
+++ b/src/Test/TestCases.Workflows/ValidationOptimizationTests.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Activities;
+using System.Activities.Expressions;
+using System.Activities.Statements;
+using System.Activities.Validation;
+using System.Activities.XamlIntegration;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualBasic.Activities;
+using Shouldly;
+using Xunit;
+
+namespace TestCases.Workflows
+{
+    public class ValidationOptimizationTests
+    {
+
+        [Fact]
+        public void ValidationWithSkipImplementation()
+        {
+            //Even if there should be a compilation error, validation with SkipImplementationChildren should not show it
+            var wf = new Sequence
+            {
+                Activities =
+                {
+                    new LogMessage()
+                    {
+                        privateMessage = new InArgument<string>("bla")
+                    }
+                }
+            };
+
+            var result = ActivityValidationServices.Validate(wf, new ValidationSettings
+            {
+                ForceExpressionCache = false,
+                SkipImplementationChildren = true,
+            });
+            result.Errors.Count.ShouldBe(0);
+
+            var result2 = ActivityValidationServices.Validate(wf, new ValidationSettings
+            {
+                ForceExpressionCache = false,
+                SkipImplementationChildren = false,
+            });
+            result2.Errors.Count.ShouldBe(1);
+
+        }
+
+        [Fact]
+        public void ValidationWithSkipImplementation_SkipFalse()
+        {
+            //Normal use case (SkipImplementationChildren = false) where the activity is validated, and error is shown
+            var wf = new Sequence
+            {
+                Activities =
+                {
+                    new LogMessage()
+                    { 
+                        privateMessage = new InArgument<string>("bla")
+                    }
+                }
+            };
+
+
+            var result = ActivityValidationServices.Validate(wf, new ValidationSettings
+            {
+                ForceExpressionCache = false,
+                SkipImplementationChildren = false,
+            });
+            result.Errors.Count.ShouldBe(1);
+        }
+
+        [Fact]
+        public void ValidationWithSkipImplementation_DynamicActivityWorks()
+        {
+            //Tests that a activities in a dynamic activity are validated, and not skipped.
+            var wf = new Sequence
+            {
+                Activities =
+                {
+                    new LogMessage()
+                    {
+                        privateMessage= new InArgument<string>(new VisualBasicValue<string>("inexistentVariable")),
+                    }
+                }
+            };
+
+
+            var dynamicActivity = new DynamicActivity
+            {
+                Implementation = () => wf
+            };
+
+
+            var result = ActivityValidationServices.Validate(dynamicActivity, new ValidationSettings
+            {
+                ForceExpressionCache = false,
+                SkipImplementationChildren = true,
+            });
+            result.Errors.Count.ShouldBe(1);
+        }
+    }
+
+
+
+
+    [Browsable(true)]
+    [Category("SimpleLibrary")]
+    [DisplayName("LogMessage")]
+    [Description("UPTF000000B4eyI8SGVscExpbms+a19fQmFja2luZ0ZpZWxkIjpudWxsLCI8SW5pdGlhbFRvb2x0aXA+a19fQmFja2luZ0ZpZWxkIjpudWxsLCI8VG9vbHRpcD5rX19CYWNraW5nRmllbGQiOm51bGwsIjxWZXJzaW9uPmtfX0JhY2tpbmdGaWVsZCI6MX0=")]
+    public class LogMessage : Activity
+    {
+
+        [Category("Input")]
+        public InArgument<string> privateMessage { get; set; }
+
+        internal Dictionary<object, string> ConstructorIdRefDictionary { get; set; }
+
+        internal Dictionary<object, string> IdRefDictionary { get; set; }
+
+        public LogMessage()
+        {
+
+            ConstructorIdRefDictionary = new Dictionary<object, string>();
+            this.Implementation = GetImplementation;
+        }
+
+        private Activity GetImplementation()
+        {
+            IdRefDictionary = new Dictionary<object, string>(ConstructorIdRefDictionary);
+
+            Sequence sequence = new Sequence{ DisplayName = "Sequence"};
+            Collection<Activity> activities = sequence.Activities;
+
+            WriteLine invalidWriteLine = new WriteLine
+            {
+                Text = new InArgument<string>(new VisualBasicValue<string>("inexistentVariable")),
+                DisplayName = "Log Message - not compiling"
+            };
+            activities.Add(invalidWriteLine);
+
+
+            return sequence;
+        }
+    }
+
+}

--- a/src/UiPath.Workflow.Runtime/ActivityUtilities.cs
+++ b/src/UiPath.Workflow.Runtime/ActivityUtilities.cs
@@ -596,15 +596,16 @@ internal static class ActivityUtilities
             };
 
             int nextEnvironmentId = 0;
+            bool shouldProcessChildren = !options.SkipPrivateChildren || (activity is DynamicActivity);
 
             ProcessChildren(activity, activity.Children, ActivityCollectionType.Public, true, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
             ProcessChildren(activity, activity.ImportedChildren, ActivityCollectionType.Imports, true, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
-            ProcessChildren(activity, activity.ImplementationChildren, ActivityCollectionType.Implementation, !options.SkipPrivateChildren, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
+            ProcessChildren(activity, activity.ImplementationChildren, ActivityCollectionType.Implementation, shouldProcessChildren, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
 
             ProcessArguments(activity, activity.RuntimeArguments, true, ref newImplementationEnvironment, ref nextEnvironmentId, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
 
             ProcessVariables(activity, activity.RuntimeVariables, ActivityCollectionType.Public, true, ref newPublicEnvironment, ref nextEnvironmentId, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
-            ProcessVariables(activity, activity.ImplementationVariables, ActivityCollectionType.Implementation, !options.SkipPrivateChildren, ref newImplementationEnvironment, ref nextEnvironmentId, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
+            ProcessVariables(activity, activity.ImplementationVariables, ActivityCollectionType.Implementation, true, ref newImplementationEnvironment, ref nextEnvironmentId, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
 
             if (activity.HandlerOf != null)
             {
@@ -653,7 +654,7 @@ internal static class ActivityUtilities
             // ProcessDelegates uses activity.Environment
             ProcessDelegates(activity, activity.Delegates, ActivityCollectionType.Public, true, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
             ProcessDelegates(activity, activity.ImportedDelegates, ActivityCollectionType.Imports, true, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
-            ProcessDelegates(activity, activity.ImplementationDelegates, ActivityCollectionType.Implementation, !options.SkipPrivateChildren, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
+            ProcessDelegates(activity, activity.ImplementationDelegates, ActivityCollectionType.Implementation, true, ref nextActivity, ref activitiesRemaining, ref tempValidationErrors);
 
             callback?.Invoke(childActivity, parentChain);
 

--- a/src/UiPath.Workflow.Runtime/ProcessActivityTreeOptions.cs
+++ b/src/UiPath.Workflow.Runtime/ProcessActivityTreeOptions.cs
@@ -265,6 +265,12 @@ internal class ProcessActivityTreeOptions
             result = ValidationOptions;
         }
 
+        if (settings.SkipImplementationChildren)
+        {
+            result = result.Clone();
+            result.SkipPrivateChildren = true;
+        }
+       
         return settings.CancellationToken == CancellationToken.None
             ? result
             : AttachCancellationToken(result, settings.CancellationToken);

--- a/src/UiPath.Workflow.Runtime/Validation/ValidationSettings.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ValidationSettings.cs
@@ -81,4 +81,11 @@ public class ValidationSettings
     /// Defaulting to true until validation path is proven.
     /// </remarks>
     public bool ForceExpressionCache { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value that indicates whether skipping validation/metadata caching for implementation children.
+    /// Implementation children are usually encapsulated, and are considered an implementation detail of an activity, so
+    /// in particular situation (such as design-time validation), validating them is not necessary.
+    /// </summary>
+    public bool SkipImplementationChildren { get; set; } = false;
 }


### PR DESCRIPTION
Validation with ValidationSettings.SkipImplementationChildren = true, will skip "implementation" children validation, speeding things up. 

Exception: DynamicActivities will not be skipped.

In order to skip our libraries there are two options:
- We mark individual libraries in a way so that we would skip validation
- We define a more generic way how an activity should look like, in order to be skipped. 

For having immediate results, this PR is about the second choice. We noticed that our libraries are defined by a custom activity with static arguments, but dynamic "implementation" usually of a sequence, or other activity. So this is our ideal case. We also noticed that in our designer the parent activity is a DynamicActivity, which would mean that everything in the current workflow will be skipped, so I added this extra condition to not skip DynamicActivities. A little bit "custom" I guess. 

If not covered by e2e tests, or manually tested thoroughly, there is some risk that we skip validation in undesired cases, like using some constraints on some activities that would validate their parents for example (tbd). 