### PR TITLE
[ROBO-4382] Use an already used namespace for StatementBehaviourExtension

### DIFF
--- a/src/Test/TestCases.Runtime/StatementsBehaviorExtensionTests.cs
+++ b/src/Test/TestCases.Runtime/StatementsBehaviorExtensionTests.cs
@@ -4,7 +4,6 @@ using System.Activities.Statements;
 using System.Threading;
 using Shouldly;
 using Test.Common.TestObjects.CustomActivities;
-using UiPath.Workflow.Runtime.Statements;
 using WorkflowApplicationTestExtensions.Persistence;
 using Xunit;
 
@@ -21,12 +20,12 @@ namespace TestCases.Runtime
             var testSequence = new Sequence()
             {
                 Activities =
-            {
-                new Delay()
                 {
-                    Duration = TimeSpan.FromMilliseconds(100)
-                },
-            }
+                    new Delay()
+                    {
+                        Duration = TimeSpan.FromMilliseconds(100)
+                    },
+                }
             };
             bool workflowIdleAndPersistable = false;
             var completed = new ManualResetEvent(false);
@@ -49,12 +48,12 @@ namespace TestCases.Runtime
             var testSequence = new Sequence()
             {
                 Activities =
-            {
-                new Delay()
                 {
-                    Duration = TimeSpan.FromMilliseconds(100)
-                },
-            }
+                    new Delay()
+                    {
+                        Duration = TimeSpan.FromMilliseconds(100)
+                    },
+                }
             };
             bool workflowIdleAndPersistable = false;
             var completed = new ManualResetEvent(false);
@@ -79,16 +78,16 @@ namespace TestCases.Runtime
             var testSequence = new Sequence()
             {
                 Activities =
-            {
-                new Parallel()
                 {
-                    Branches =
+                    new Parallel()
                     {
-                        new Delay() { Duration = delayDuration  },
-                        new BlockingActivity("B")
-                    }
-                },
-            }
+                        Branches =
+                        {
+                            new Delay() { Duration = delayDuration  },
+                            new BlockingActivity("B")
+                        }
+                    },
+                }
             };
             bool workflowIdleAndPersistable = false;
             var completed = new ManualResetEvent(false);

--- a/src/UiPath.Workflow.Runtime/Statements/Delay.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/Delay.cs
@@ -4,7 +4,6 @@
 using System.Activities.Runtime;
 using System.Collections.ObjectModel;
 using System.Windows.Markup;
-using UiPath.Workflow.Runtime.Statements;
 
 namespace System.Activities.Statements;
 

--- a/src/UiPath.Workflow.Runtime/Statements/StatementsBehaviorExtension.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/StatementsBehaviorExtension.cs
@@ -4,17 +4,16 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace UiPath.Workflow.Runtime.Statements
+namespace System.Activities.Statements;
+
+/// <summary>
+/// An extension that configures/changes the behavior of some statements like Delay.
+/// </summary>
+public class StatementsBehaviorExtension
 {
     /// <summary>
-    /// An extension that configures/changes the behavior of some statements like Delay.
+    /// When true, the delay activity will block the persistance idle event until the delay is over, 
+    /// preventing the workflow from being persisted.
     /// </summary>
-    public class StatementsBehaviorExtension
-    {
-        /// <summary>
-        /// When true, the delay activity will block the persistance idle event until the delay is over, 
-        /// preventing the workflow from being persisted.
-        /// </summary>
-        public bool BlockingDelay { get; set; } = false;
-    }
+    public bool BlockingDelay { get; set; } = false;
 }


### PR DESCRIPTION
Changing UiPath.Workflow.Runtime.Statements to an already used namespace System.Activities.Statements for StatementBehaviourExtension