### PR TITLE
STUD-74767 Added an option so that we don't have to compile expressions when validating

### DIFF
--- a/src/UiPath.Workflow.Runtime/Expressions/ExpressionEvaluationSettings.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/ExpressionEvaluationSettings.cs
@@ -1,0 +1,20 @@
+// This file is part of Core WF which is licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+using System.Activities.Runtime;
+
+namespace System.Activities.Expressions;
+
+/// <summary>
+/// Represents settings that control how expressions are evaluated at runtime.
+/// </summary>
+[Fx.Tag.XamlVisible(false)]
+public class ExpressionEvaluationSettings
+{
+    /// <summary>
+    /// Gets or sets a value that indicates whether lambda expressions should prefer interpretation over compilation.
+    /// When true, lambda expressions will be interpreted at runtime rather than compiled to IL. 
+    /// This can be faster, especially for one-time only evaluation.
+    /// </summary>
+    public bool PreferExpressionInterpretation { get; set; }
+} 

--- a/src/UiPath.Workflow.Runtime/Expressions/LambdaValue.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/LambdaValue.cs
@@ -3,7 +3,9 @@
 
 using System.Activities.Runtime;
 using System.Activities.XamlIntegration;
+using System.Activities.Validation;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Windows.Markup;
 
 namespace System.Activities.Expressions;
@@ -43,7 +45,8 @@ public sealed class LambdaValue<TResult> : CodeActivity<TResult>, IExpressionCon
 
     protected override TResult Execute(CodeActivityContext context)
     {
-        _compiledLambdaValue ??= _rewrittenTree.Compile();
+        var settings = context.GetExtension<ExpressionEvaluationSettings>();
+        _compiledLambdaValue ??= _rewrittenTree.Compile(settings?.PreferExpressionInterpretation ?? false);
         return _compiledLambdaValue(context);
     }
 

--- a/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
@@ -353,9 +353,10 @@ public static class ActivityValidationServices
                 try
                 {
                     var invoker = new WorkflowInvoker(constraint);
-                    
-                    if (validationContext.Environment.Extensions != null)
-                    foreach (var e in validationContext.Environment.Extensions?.All)
+
+                    var extensions = validationContext.Environment.Extensions?.All;
+                    if (extensions != null)
+                    foreach (var e in extensions)
                     {
                         invoker.Extensions.Add(e);
                     }

--- a/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
@@ -353,16 +353,12 @@ public static class ActivityValidationServices
                 try
                 {
                     var invoker = new WorkflowInvoker(constraint);
-
                     var extensions = validationContext.Environment.Extensions?.All;
                     if (extensions != null)
                     foreach (var e in extensions)
                     {
                         invoker.Extensions.Add(e);
                     }
-                    
-                    //add extensions to the invoker
-
                     results = invoker.Invoke(inputDictionary);
                 }
                 catch (Exception e)

--- a/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
@@ -1,9 +1,11 @@
 // This file is part of Core WF which is licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using System.Activities.Expressions;
 using System.Activities.Runtime;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Runtime;
 using System.Text;
 
 namespace System.Activities.Validation;
@@ -350,7 +352,15 @@ public static class ActivityValidationServices
 
                 try
                 {
-                    results = WorkflowInvoker.Invoke(constraint, inputDictionary);
+                    var invoker = new WorkflowInvoker(constraint);
+                    foreach (var e in validationContext.Environment.Extensions.All)
+                    {
+                        invoker.Extensions.Add(e);
+                    }
+                    
+                    //add extensions to the invoker
+
+                    results = invoker.Invoke(inputDictionary);
                 }
                 catch (Exception e)
                 {
@@ -430,6 +440,14 @@ public static class ActivityValidationServices
             _settings = settings;
             _rootToValidate = toValidate;
             _environment = settings.Environment ?? new ActivityLocationReferenceEnvironment();
+
+            // Add the expression evaluation extension based on Validation settings
+            var expressionSettings = new ExpressionEvaluationSettings
+            {
+                PreferExpressionInterpretation = settings.PreferExpressionInterpretation
+            };
+            _environment.Extensions.Add(expressionSettings);
+
             _environment.IsValidating = !settings.ForceExpressionCache;
             if (settings.SkipExpressionCompilation)
             {

--- a/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
@@ -353,7 +353,9 @@ public static class ActivityValidationServices
                 try
                 {
                     var invoker = new WorkflowInvoker(constraint);
-                    foreach (var e in validationContext.Environment.Extensions.All)
+                    
+                    if (validationContext.Environment.Extensions != null)
+                    foreach (var e in validationContext.Environment.Extensions?.All)
                     {
                         invoker.Extensions.Add(e);
                     }

--- a/src/UiPath.Workflow.Runtime/Validation/ValidationSettings.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ValidationSettings.cs
@@ -88,4 +88,10 @@ public class ValidationSettings
     /// in particular situation (such as design-time validation), validating them is not necessary.
     /// </summary>
     public bool SkipImplementationChildren { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a value that indicates whether lambda expressions should prefer interpretation over compilation.
+    /// When true, lambda expressions will be interpreted at runtime rather than compiled to IL.
+    /// </summary>
+    public bool PreferExpressionInterpretation { get; set; } = false;
 }


### PR DESCRIPTION
During validation, most of the time is lost when the expressions are compiled (lambda expressions are compiled with JIT). Compiling makes sense for expression reuse, but in some cases, when we don't want to reuse them, we want to optimize for speed, and interpreting the expressions vs compiling them is usually faster. 