### PR TITLE
use a best-effort metadata reference resolver

### DIFF
--- a/src/Test/TestCases.Workflows/ReferencesResolverTests.cs
+++ b/src/Test/TestCases.Workflows/ReferencesResolverTests.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.VisualBasic.Activities;
+using System;
+using System.Activities.Statements;
+using System.Activities.Validation;
+using System.Activities;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Shouldly;
+using System.Activities.Expressions;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace TestCases.Workflows
+{
+    public class ReferencesResolverTests
+    {
+        private Func<AssemblyName, Assembly> _resolver = (name) =>
+        {
+            foreach (var assembly in AssemblyLoadContext.All.SelectMany(ctx => ctx.Assemblies))
+            {
+                var other = assembly.GetName();
+
+                if(name.Name == other.Name && name.Version == other.Version && name.GetPublicKeyToken().SequenceEqual(other.GetPublicKeyToken()))
+                {
+                    return assembly;
+                }
+            }
+
+            return null;
+        };
+
+        [Fact]
+        public void Validation_WithoutMetadataReferenceResolver_ShouldFail()
+        {
+            ValidationResults validationResults = Validate(false);
+            validationResults.Errors.Any(e => e.Message.Contains("Reference required to assembly 'System.Memory")).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Validation_WithoutMetadataReferenceResolver_ShouldSucceed()
+        {
+            ValidationResults validationResults = Validate(true);
+            validationResults.Errors.ShouldBeEmpty();
+        }
+
+        private ValidationResults Validate(bool useMetadataReferenceResolver)
+        {
+            string expression = @"System.Text.Json.JsonDocument.Parse("""").ToString()";
+
+            VisualBasicValue<string> vbv = new(expression);
+            WriteLine writeLine = new();
+            writeLine.Text = new InArgument<string>(vbv);
+            Sequence workflow = new();
+            workflow.Activities.Add(writeLine);
+
+            TextExpression.SetReferencesForImplementation(workflow, new[] { new AssemblyReference("System.Text.Json") });
+            TextExpression.SetNamespacesForImplementation(workflow, new[] { "System.Text.Json" });
+
+            var settings = new ValidationSettings();
+            settings.SkipExpressionCompilation = false;
+            settings.SkipImplementationChildren = false;
+            settings.SkipValidatingRootConfiguration = false;
+            settings.ForceExpressionCache = false;
+
+            if (useMetadataReferenceResolver)
+            {
+                settings.MissingAssemblyResolver = _resolver;
+            }
+
+            ValidationResults validationResults = ActivityValidationServices.Validate(workflow, settings);
+            return validationResults;
+        }
+    }
+}

--- a/src/Test/TestCases.Workflows/ValidationExtensionsTests.cs
+++ b/src/Test/TestCases.Workflows/ValidationExtensionsTests.cs
@@ -70,7 +70,7 @@ public class ValidationExtensionsTests
 
     class MockValidationExtension : IValidationExtension
     {
-        public IEnumerable<ValidationError> PostValidate(Activity activity) =>
+        public IEnumerable<ValidationError> PostValidate(Activity activity, ValidationSettings validationSettings) =>
             new List<ValidationError>() { new ValidationError(nameof(MockValidationExtension)) };
     }
 }

--- a/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ActivityValidationServices.cs
@@ -474,7 +474,7 @@ public static class ActivityValidationServices
             return new ValidationResults(GetValidationExtensionResults().Concat(_errors ?? Array.Empty<ValidationError>()).ToList());
 
             IEnumerable<ValidationError> GetValidationExtensionResults() =>
-                _environment.Extensions.All.OfType<IValidationExtension>().SelectMany(validationExtension => validationExtension.PostValidate(_rootToValidate));
+                _environment.Extensions.All.OfType<IValidationExtension>().SelectMany(validationExtension => validationExtension.PostValidate(_rootToValidate, _settings));
         }
 
         private void ValidateElement(ActivityUtilities.ChildActivity childActivity, ActivityUtilities.ActivityCallStack parentChain)

--- a/src/UiPath.Workflow.Runtime/Validation/IValidationExtension.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/IValidationExtension.cs
@@ -2,6 +2,6 @@
 {
     internal interface IValidationExtension
     {
-        IEnumerable<ValidationError> PostValidate(Activity activity);
+        IEnumerable<ValidationError> PostValidate(Activity activity, ValidationSettings validationSettings);
     }
 }

--- a/src/UiPath.Workflow.Runtime/Validation/ValidationSettings.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ValidationSettings.cs
@@ -2,6 +2,7 @@
 // See LICENSE file in the project root for full license information.
 
 using System.Activities.Runtime;
+using System.Reflection;
 using System.Threading;
 
 namespace System.Activities.Validation;
@@ -94,4 +95,9 @@ public class ValidationSettings
     /// When true, lambda expressions will be interpreted at runtime rather than compiled to IL.
     /// </summary>
     public bool PreferExpressionInterpretation { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a function that resolves missing assemblies during compilation for validation.
+    /// </summary>
+    public Func<AssemblyName, Assembly> MissingAssemblyResolver { get; set; }
 }

--- a/src/UiPath.Workflow/Validation/CSharpExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/CSharpExpressionValidator.cs
@@ -47,7 +47,7 @@ public class CSharpExpressionValidator : RoslynExpressionValidator
         : base(referencedAssemblies)
     { }
 
-    protected override Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces, ValidationSettings validationSettings)
+    protected override Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces, ValidationSettings validationSettings = null)
     {
         var metadataReferences = GetMetadataReferencesForExpression(assemblies);
 

--- a/src/UiPath.Workflow/Validation/CSharpExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/CSharpExpressionValidator.cs
@@ -7,6 +7,7 @@ using Microsoft.CSharp.Activities;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using UiPath.Workflow.Validation;
 using static System.Activities.CompilerHelper;
 
 namespace System.Activities.Validation;
@@ -46,12 +47,19 @@ public class CSharpExpressionValidator : RoslynExpressionValidator
         : base(referencedAssemblies)
     { }
 
-    protected override Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces)
+    protected override Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces, ValidationSettings validationSettings)
     {
         var metadataReferences = GetMetadataReferencesForExpression(assemblies);
 
         var options = CompilerHelper.DefaultCompilationUnit.Options as CSharpCompilationOptions;
-        return CompilerHelper.DefaultCompilationUnit.WithOptions(options.WithUsings(namespaces)).WithReferences(metadataReferences);
+        var compilation = CompilerHelper.DefaultCompilationUnit.WithOptions(options.WithUsings(namespaces)).WithReferences(metadataReferences);
+
+        if(validationSettings?.MissingAssemblyResolver is Func<AssemblyName, Assembly> resolver)
+        {
+            compilation = compilation.WithOptions(options.WithMetadataReferenceResolver(new ExternalMetadataReferenceResolver(resolver)));
+        }
+
+        return compilation;
     }
 
     protected override string CreateValueCode(IEnumerable<string> types, string names, string code, string activityId, int index)

--- a/src/UiPath.Workflow/Validation/ExternalMetadataReferenceResolver.cs
+++ b/src/UiPath.Workflow/Validation/ExternalMetadataReferenceResolver.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace UiPath.Workflow.Validation
 {
-    public class ExternalMetadataReferenceResolver : MetadataReferenceResolver
+    internal sealed class ExternalMetadataReferenceResolver : MetadataReferenceResolver
     {
         private readonly Func<AssemblyName, Assembly> _resolver;
 
@@ -33,7 +33,7 @@ namespace UiPath.Workflow.Validation
 
                 assemblyName.SetPublicKeyToken(referenceIdentity.PublicKeyToken.ToArray());
 
-                var assembly = _resolver?.Invoke(assemblyName);
+                var assembly = _resolver.Invoke(assemblyName);
 
                 if (string.IsNullOrEmpty(assembly?.Location))
                     return null;

--- a/src/UiPath.Workflow/Validation/ExternalMetadataReferenceResolver.cs
+++ b/src/UiPath.Workflow/Validation/ExternalMetadataReferenceResolver.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+
+namespace UiPath.Workflow.Validation
+{
+    public class ExternalMetadataReferenceResolver : MetadataReferenceResolver
+    {
+        private readonly Func<AssemblyName, Assembly> _resolver;
+
+        public override bool ResolveMissingAssemblies => true;
+
+        public ExternalMetadataReferenceResolver(Func<AssemblyName, Assembly> resolver)
+        {
+            _resolver = resolver;
+        }
+
+        public override PortableExecutableReference? ResolveMissingAssembly(MetadataReference definition, AssemblyIdentity referenceIdentity)
+        {
+            try
+            {
+                if (referenceIdentity is null || _resolver is null)
+                    return null;
+
+                var assemblyName = new AssemblyName
+                {
+                    Name = referenceIdentity.Name,
+                    Version = referenceIdentity.Version,
+                    CultureName = referenceIdentity.CultureName,
+                };
+
+                assemblyName.SetPublicKeyToken(referenceIdentity.PublicKeyToken.ToArray());
+
+                var assembly = _resolver?.Invoke(assemblyName);
+
+                if (string.IsNullOrEmpty(assembly?.Location))
+                    return null;
+
+                return MetadataReference.CreateFromFile(assembly.Location);
+            }
+            catch
+            {
+                // In case of any exception, return null
+                return null;
+            }
+        }
+
+        public override ImmutableArray<PortableExecutableReference> ResolveReference(
+            string reference, string? baseFilePath, MetadataReferenceProperties properties)
+        {
+            return ImmutableArray<PortableExecutableReference>.Empty;
+        }
+
+        public override bool Equals(object? other) => ReferenceEquals(this, other);
+        public override int GetHashCode() => GetType().GetHashCode();
+    }
+}

--- a/src/UiPath.Workflow/Validation/RoslynExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/RoslynExpressionValidator.cs
@@ -116,7 +116,7 @@ public abstract class RoslynExpressionValidator
     /// </summary>
     /// <param name="assemblies">The list of assemblies</param>
     /// <param name="namespaces">The list of namespaces</param>
-    protected abstract Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces);
+    protected abstract Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces, ValidationSettings validationSettings);
 
     /// <summary>
     ///     Gets the <see cref="SyntaxTree" /> for the expression.
@@ -187,7 +187,7 @@ public abstract class RoslynExpressionValidator
         }
     }
 
-    internal IList<ValidationError> Validate(Activity currentActivity, ValidationScope validationScope)
+    internal IList<ValidationError> Validate(Activity currentActivity, ValidationScope validationScope, ValidationSettings validationSettings)
     {
         if (validationScope is null)
         {
@@ -200,7 +200,7 @@ public abstract class RoslynExpressionValidator
         requiredAssemblies.UnionWith(localAssemblies.Where(aref => aref is not null).Select(aref => aref.Assembly ?? LoadAssemblyFromReference(aref)));
         localNamespaces.AddRange(CompilerHelper.DefaultNamespaces);
 
-        var compilation = GetCompilation(requiredAssemblies, localNamespaces);
+        var compilation = GetCompilation(requiredAssemblies, localNamespaces, validationSettings);
         var expressionsTextBuilder = new StringBuilder();
         int index = 0;
         foreach (var expressionToValidate in validationScope.GetAllExpressions())

--- a/src/UiPath.Workflow/Validation/RoslynExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/RoslynExpressionValidator.cs
@@ -116,7 +116,7 @@ public abstract class RoslynExpressionValidator
     /// </summary>
     /// <param name="assemblies">The list of assemblies</param>
     /// <param name="namespaces">The list of namespaces</param>
-    protected abstract Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces, ValidationSettings validationSettings);
+    protected abstract Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces, ValidationSettings validationSettings = null);
 
     /// <summary>
     ///     Gets the <see cref="SyntaxTree" /> for the expression.

--- a/src/UiPath.Workflow/Validation/VBExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/VBExpressionValidator.cs
@@ -46,7 +46,7 @@ public class VbExpressionValidator : RoslynExpressionValidator
 
     protected override string ActivityIdentifierRegex { get; } = "('activityId):(.*)";
 
-    protected override Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces, ValidationSettings validationSettings)
+    protected override Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces, ValidationSettings validationSettings = null)
     {
         var globalImports = GlobalImport.Parse(namespaces);
         var metadataReferences = GetMetadataReferencesForExpression(assemblies);

--- a/src/UiPath.Workflow/Validation/VBExpressionValidator.cs
+++ b/src/UiPath.Workflow/Validation/VBExpressionValidator.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualBasic.Activities;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using UiPath.Workflow.Validation;
 using static System.Activities.CompilerHelper;
 
 namespace System.Activities.Validation;
@@ -45,13 +46,20 @@ public class VbExpressionValidator : RoslynExpressionValidator
 
     protected override string ActivityIdentifierRegex { get; } = "('activityId):(.*)";
 
-    protected override Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces)
+    protected override Compilation GetCompilation(IReadOnlyCollection<Assembly> assemblies, IReadOnlyCollection<string> namespaces, ValidationSettings validationSettings)
     {
         var globalImports = GlobalImport.Parse(namespaces);
         var metadataReferences = GetMetadataReferencesForExpression(assemblies);
 
         var options = CompilerHelper.DefaultCompilationUnit.Options as VisualBasicCompilationOptions;
-        return CompilerHelper.DefaultCompilationUnit.WithOptions(options!.WithGlobalImports(globalImports)).WithReferences(metadataReferences);
+        var compilation = CompilerHelper.DefaultCompilationUnit.WithOptions(options!.WithGlobalImports(globalImports)).WithReferences(metadataReferences);
+
+        if (validationSettings?.MissingAssemblyResolver is Func<AssemblyName, Assembly> resolver)
+        {
+            compilation = compilation.WithOptions(options.WithMetadataReferenceResolver(new ExternalMetadataReferenceResolver(resolver)));
+        }
+
+        return compilation;
     }
 
     protected override SyntaxTree GetSyntaxTreeForExpression(string expressionText) =>

--- a/src/UiPath.Workflow/Validation/ValidationExtension.cs
+++ b/src/UiPath.Workflow/Validation/ValidationExtension.cs
@@ -6,10 +6,10 @@ namespace System.Activities.Validation
 {
     internal sealed class ValidationExtension : IValidationExtension
     {
-        public IEnumerable<ValidationError> PostValidate(Activity activity)
+        public IEnumerable<ValidationError> PostValidate(Activity activity, ValidationSettings validationSettings)
         {
             var validator = GetValidator(Scope.Language);
-            return validator.Validate(activity, Scope);
+            return validator.Validate(activity, Scope, validationSettings);
         }
 
         private static RoslynExpressionValidator GetValidator(string language)


### PR DESCRIPTION
If assembly A from the set used for compilation depends on assembly B, and some type from assembly B is used in the expression, compilation will fail. 

So use a MetadataReferenceResolver which looks in all contexts for that particular assembly.

For now, this was only done for (compilation for) validation, though I suspect it might be useful for other compilations as well (studio compiler, precompiled expressions for designer and any others).


https://uipath.atlassian.net/browse/STUD-75944