### PR TITLE
Add performance optimization plans for AssemblyReference.GetAssembly method

### DIFF
--- a/src/UiPath.Workflow.Runtime/Expressions/Optimization1.md
+++ b/src/UiPath.Workflow.Runtime/Expressions/Optimization1.md
@@ -1,0 +1,57 @@
+# Optimization 1: Replace Hashtable with ConcurrentDictionary
+
+## Problem
+
+The current implementation uses `Hashtable` with manual locking for thread safety. This approach has several performance issues:
+
+1. **Coarse-grained locking**: The entire cache is locked during read/write operations, creating a bottleneck when multiple threads try to access the cache concurrently.
+2. **Lock contention**: Even read operations require acquiring a lock, which is unnecessary when the cache is already populated.
+3. **Double-checked locking pattern**: While this reduces lock acquisition for initialization, it still requires locking for every cache update.
+4. **Hashtable overhead**: `Hashtable` is a legacy collection that boxes value types and has additional overhead compared to modern collections.
+
+## Solution
+
+Replace `Hashtable` with `ConcurrentDictionary<TKey, TValue>` which provides:
+
+1. **Lock-free reads**: Multiple threads can read from the dictionary simultaneously without blocking.
+2. **Fine-grained locking**: Updates use segment-based locking, allowing multiple threads to update different parts of the dictionary concurrently.
+3. **Better performance**: Generic collections avoid boxing and provide better type safety.
+4. **Atomic operations**: Methods like `GetOrAdd` provide atomic read-or-update semantics.
+
+### Implementation Details
+
+```csharp
+// Replace:
+private static volatile Hashtable assemblyCache;
+private static readonly object assemblyCacheLock = new();
+
+// With:
+private static readonly ConcurrentDictionary<AssemblyName, Assembly> assemblyCache = 
+    new ConcurrentDictionary<AssemblyName, Assembly>(
+        Environment.ProcessorCount * 2, 
+        AssemblyCacheInitialSize, 
+        new AssemblyNameEqualityComparer());
+
+// Replace:
+private static volatile Hashtable assemblyToAssemblyNameCache;
+private static readonly object assemblyToAssemblyNameCacheLock = new();
+
+// With:
+private static readonly ConcurrentDictionary<Assembly, AssemblyName> assemblyToAssemblyNameCache = 
+    new ConcurrentDictionary<Assembly, AssemblyName>(
+        Environment.ProcessorCount * 2, 
+        AssemblyToAssemblyNameCacheInitSize);
+```
+
+### Benefits
+
+1. **Improved throughput**: Multiple threads can read cached assemblies without blocking each other.
+2. **Reduced latency**: No lock acquisition needed for cache hits.
+3. **Better scalability**: Performance scales better with the number of CPU cores.
+4. **Simpler code**: Eliminates the need for manual locking and double-checked locking patterns.
+
+### Estimated Performance Impact
+
+- **Read operations**: 5-10x improvement under high concurrency
+- **Write operations**: 2-3x improvement due to fine-grained locking
+- **Memory usage**: Slight increase (10-20%) due to ConcurrentDictionary overhead, but acceptable for the performance gain

--- a/src/UiPath.Workflow.Runtime/Expressions/Optimization2.md
+++ b/src/UiPath.Workflow.Runtime/Expressions/Optimization2.md
@@ -1,0 +1,140 @@
+# Optimization 2: Implement Two-Level Caching with Read-Through Pattern
+
+## Problem
+
+The current `GetAssembly` method has several performance bottlenecks:
+
+1. **Expensive array creation**: `AssemblyLoadContext.All.SelectMany(c=>c.Assemblies).ToArray()` creates a new array on every cache miss.
+2. **Linear search**: Searching through all assemblies from end to start is O(n) operation.
+3. **Repeated lookups**: When multiple threads look for the same assembly simultaneously, they all perform the expensive search operation.
+4. **No negative caching**: Failed lookups are not cached, causing repeated expensive searches for non-existent assemblies.
+
+## Solution
+
+Implement a two-level caching strategy with a read-through pattern:
+
+1. **Level 1 (L1) Cache**: Fast, lock-free cache for frequently accessed assemblies
+2. **Level 2 (L2) Cache**: Comprehensive cache with negative caching support
+3. **Read-through loader**: Single-execution guarantee for assembly loading
+
+### Implementation Details
+
+```csharp
+public class AssemblyCache
+{
+    private readonly struct CacheEntry
+    {
+        public readonly Assembly Assembly;
+        public readonly DateTime Timestamp;
+        public readonly bool IsNegative; // true if assembly was not found
+        
+        public CacheEntry(Assembly assembly, bool isNegative = false)
+        {
+            Assembly = assembly;
+            Timestamp = DateTime.UtcNow;
+            IsNegative = isNegative;
+        }
+    }
+    
+    // L1: Most recently used assemblies (lock-free read)
+    private readonly ConcurrentDictionary<AssemblyName, CacheEntry> _l1Cache;
+    
+    // L2: All assemblies with negative caching
+    private readonly ConcurrentDictionary<AssemblyName, Lazy<CacheEntry>> _l2Cache;
+    
+    // Cached assembly list snapshot
+    private volatile AssemblySnapshot _assemblySnapshot;
+    private readonly Timer _snapshotRefreshTimer;
+    
+    private class AssemblySnapshot
+    {
+        public readonly Dictionary<string, Assembly> ByFullName;
+        public readonly Dictionary<string, List<Assembly>> BySimpleName;
+        public readonly DateTime Timestamp;
+        
+        public AssemblySnapshot(Assembly[] assemblies)
+        {
+            ByFullName = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
+            BySimpleName = new Dictionary<string, List<Assembly>>(StringComparer.OrdinalIgnoreCase);
+            Timestamp = DateTime.UtcNow;
+            
+            // Build indexes for fast lookup
+            foreach (var asm in assemblies.Where(a => !a.IsDynamic && !a.IsCollectible))
+            {
+                ByFullName[asm.FullName] = asm;
+                
+                var simpleName = asm.GetName().Name;
+                if (!BySimpleName.TryGetValue(simpleName, out var list))
+                {
+                    list = new List<Assembly>();
+                    BySimpleName[simpleName] = list;
+                }
+                list.Add(asm);
+            }
+        }
+    }
+    
+    public Assembly GetAssembly(AssemblyName assemblyName)
+    {
+        // L1 cache check (fastest path)
+        if (_l1Cache.TryGetValue(assemblyName, out var l1Entry) && !l1Entry.IsNegative)
+        {
+            return l1Entry.Assembly;
+        }
+        
+        // L2 cache with single-execution guarantee
+        var lazyEntry = _l2Cache.GetOrAdd(assemblyName, 
+            key => new Lazy<CacheEntry>(() => LoadAssembly(key), 
+                LazyThreadSafetyMode.ExecutionAndPublication));
+        
+        var entry = lazyEntry.Value;
+        
+        // Promote to L1 if successful
+        if (!entry.IsNegative)
+        {
+            _l1Cache.TryAdd(assemblyName, entry);
+            MaintainL1CacheSize();
+        }
+        
+        return entry.Assembly;
+    }
+    
+    private CacheEntry LoadAssembly(AssemblyName assemblyName)
+    {
+        // First check the snapshot
+        var snapshot = _assemblySnapshot;
+        var assembly = FindInSnapshot(snapshot, assemblyName);
+        
+        if (assembly != null)
+        {
+            return new CacheEntry(assembly);
+        }
+        
+        // Try loading from disk
+        assembly = LoadAssemblyFromDisk(assemblyName);
+        
+        if (assembly != null)
+        {
+            return new CacheEntry(assembly);
+        }
+        
+        // Negative cache entry
+        return new CacheEntry(null, isNegative: true);
+    }
+}
+```
+
+### Benefits
+
+1. **Reduced contention**: L1 cache serves most requests without any locking
+2. **Single execution**: `Lazy<T>` ensures assembly loading happens only once per assembly
+3. **Faster lookups**: Indexed snapshot provides O(1) lookup instead of O(n)
+4. **Negative caching**: Prevents repeated searches for non-existent assemblies
+5. **Automatic refresh**: Snapshot updates periodically to catch newly loaded assemblies
+
+### Estimated Performance Impact
+
+- **Cache hit (L1)**: 10-20x faster than current implementation
+- **Cache hit (L2)**: 5-10x faster than current implementation
+- **Cache miss**: 3-5x faster due to indexed search and negative caching
+- **Memory usage**: 20-30% increase, but with better cache utilization

--- a/src/UiPath.Workflow.Runtime/Expressions/Optimization3.md
+++ b/src/UiPath.Workflow.Runtime/Expressions/Optimization3.md
@@ -1,0 +1,186 @@
+# Optimization 3: Batch Processing and Request Coalescing
+
+## Problem
+
+When multiple threads request the same assembly simultaneously, the current implementation has these issues:
+
+1. **Thundering herd**: All threads waiting for the same assembly will attempt to load it when the lock is released.
+2. **Duplicate work**: Multiple threads may perform the same expensive assembly search operation.
+3. **No request batching**: Each thread processes its request independently, missing optimization opportunities.
+4. **Cache stampede**: After a cache invalidation or application start, many threads compete to populate the cache.
+
+## Solution
+
+Implement request coalescing and batch processing to handle concurrent requests more efficiently:
+
+1. **Request coalescing**: Merge multiple requests for the same assembly into a single operation
+2. **Batch loading**: Process multiple assembly requests together
+3. **Async loading**: Use async/await to avoid blocking threads during I/O operations
+4. **Predictive preloading**: Load commonly requested assemblies together
+
+### Implementation Details
+
+```csharp
+public class OptimizedAssemblyReference
+{
+    private readonly struct PendingRequest
+    {
+        public readonly AssemblyName AssemblyName;
+        public readonly TaskCompletionSource<Assembly> CompletionSource;
+        
+        public PendingRequest(AssemblyName name)
+        {
+            AssemblyName = name;
+            CompletionSource = new TaskCompletionSource<Assembly>();
+        }
+    }
+    
+    // Coalescing dictionary for in-flight requests
+    private readonly ConcurrentDictionary<AssemblyName, Task<Assembly>> _inFlightRequests;
+    
+    // Batch processor
+    private readonly Channel<PendingRequest> _requestChannel;
+    private readonly Task _batchProcessorTask;
+    
+    // Assembly group loader for common patterns
+    private readonly Dictionary<string, string[]> _assemblyGroups;
+    
+    public OptimizedAssemblyReference()
+    {
+        _inFlightRequests = new ConcurrentDictionary<AssemblyName, Task<Assembly>>(
+            new AssemblyNameEqualityComparer());
+        
+        _requestChannel = Channel.CreateUnbounded<PendingRequest>(
+            new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false
+            });
+        
+        _assemblyGroups = InitializeAssemblyGroups();
+        _batchProcessorTask = Task.Run(ProcessBatchesAsync);
+    }
+    
+    public async Task<Assembly> GetAssemblyAsync(AssemblyName assemblyName)
+    {
+        // Check cache first
+        if (TryGetFromCache(assemblyName, out var assembly))
+        {
+            return assembly;
+        }
+        
+        // Check for in-flight request (request coalescing)
+        var existingTask = _inFlightRequests.GetOrAdd(assemblyName, name =>
+        {
+            var request = new PendingRequest(name);
+            _requestChannel.Writer.TryWrite(request);
+            return request.CompletionSource.Task;
+        });
+        
+        return await existingTask.ConfigureAwait(false);
+    }
+    
+    private async Task ProcessBatchesAsync()
+    {
+        var batch = new List<PendingRequest>();
+        var batchTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(10));
+        
+        while (!_requestChannel.Reader.Completion.IsCompleted)
+        {
+            // Collect requests for batching
+            var timerTask = batchTimer.WaitForNextTickAsync().AsTask();
+            var readTask = ReadBatchAsync(batch);
+            
+            var completedTask = await Task.WhenAny(timerTask, readTask);
+            
+            if (batch.Count > 0)
+            {
+                await ProcessBatchAsync(batch);
+                batch.Clear();
+            }
+        }
+    }
+    
+    private async Task ProcessBatchAsync(List<PendingRequest> batch)
+    {
+        // Group requests by assembly characteristics
+        var groups = batch.GroupBy(r => GetAssemblyGroup(r.AssemblyName));
+        
+        // Process each group in parallel
+        var tasks = groups.Select(group => ProcessGroupAsync(group.ToList()));
+        await Task.WhenAll(tasks);
+        
+        // Clean up in-flight requests
+        foreach (var request in batch)
+        {
+            _inFlightRequests.TryRemove(request.AssemblyName, out _);
+        }
+    }
+    
+    private async Task ProcessGroupAsync(List<PendingRequest> group)
+    {
+        // Load all assemblies in the group
+        var assemblies = await LoadAssembliesAsync(group.Select(r => r.AssemblyName));
+        
+        // Complete all requests
+        foreach (var request in group)
+        {
+            var assembly = assemblies.FirstOrDefault(a => 
+                AssemblySatisfiesReference(a.GetName(), request.AssemblyName));
+            
+            if (assembly != null)
+            {
+                CacheAssembly(request.AssemblyName, assembly);
+                request.CompletionSource.SetResult(assembly);
+            }
+            else
+            {
+                request.CompletionSource.SetResult(null);
+            }
+        }
+    }
+    
+    private string GetAssemblyGroup(AssemblyName assemblyName)
+    {
+        // Identify common assembly groups for predictive loading
+        var simpleName = assemblyName.Name;
+        
+        // Check known groups (e.g., System.*, Microsoft.*, etc.)
+        foreach (var kvp in _assemblyGroups)
+        {
+            if (simpleName.StartsWith(kvp.Key, StringComparison.OrdinalIgnoreCase))
+            {
+                return kvp.Key;
+            }
+        }
+        
+        return "default";
+    }
+    
+    private Dictionary<string, string[]> InitializeAssemblyGroups()
+    {
+        // Define assembly groups that are commonly loaded together
+        return new Dictionary<string, string[]>
+        {
+            ["System."] = new[] { "System.Runtime", "System.Collections", "System.Linq" },
+            ["Microsoft."] = new[] { "Microsoft.CSharp", "Microsoft.Extensions.DependencyInjection" },
+            ["Newtonsoft."] = new[] { "Newtonsoft.Json" }
+        };
+    }
+}
+```
+
+### Benefits
+
+1. **Request coalescing**: Multiple threads requesting the same assembly share a single load operation
+2. **Batch efficiency**: Loading multiple assemblies together reduces overhead
+3. **Non-blocking**: Async operations prevent thread pool starvation
+4. **Predictive loading**: Common assembly groups are loaded together, improving cache hit rate
+5. **Reduced contention**: Channel-based design minimizes lock contention
+
+### Estimated Performance Impact
+
+- **Concurrent same-assembly requests**: 50-100x improvement (only one actual load)
+- **Batch processing**: 3-5x improvement for related assemblies
+- **Thread utilization**: 40-60% reduction in blocked threads
+- **Overall throughput**: 5-10x improvement under high concurrency

--- a/src/UiPath.Workflow.Runtime/Expressions/Optimization4.md
+++ b/src/UiPath.Workflow.Runtime/Expressions/Optimization4.md
@@ -1,0 +1,237 @@
+# Optimization 4: Memory-Mapped Assembly Index
+
+## Problem
+
+The current implementation has memory and performance issues:
+
+1. **Repeated assembly enumeration**: `AssemblyLoadContext.All.SelectMany(c=>c.Assemblies).ToArray()` allocates a large array on every cache miss
+2. **Memory pressure**: Creating arrays of all assemblies causes GC pressure
+3. **No persistence**: Assembly cache is rebuilt on every application start
+4. **Inefficient search**: Linear search through assemblies even with known assembly names
+
+## Solution
+
+Create a memory-mapped assembly index that:
+
+1. **Persists across app domains**: Shared memory reduces startup time
+2. **Zero-copy access**: Direct memory access without array allocation
+3. **Efficient indexing**: Pre-built indexes for fast lookup
+4. **Update notifications**: File system watcher for dynamic assembly loading
+
+### Implementation Details
+
+```csharp
+public class MemoryMappedAssemblyIndex : IDisposable
+{
+    private readonly struct AssemblyIndexEntry
+    {
+        public readonly long FullNameOffset;
+        public readonly long SimpleNameOffset;
+        public readonly long LocationOffset;
+        public readonly int FullNameLength;
+        public readonly int SimpleNameLength;
+        public readonly int LocationLength;
+        public readonly long VersionTicks;
+        public readonly int Flags; // IsDynamic, IsCollectible, etc.
+    }
+    
+    private readonly MemoryMappedFile _indexFile;
+    private readonly MemoryMappedViewAccessor _headerAccessor;
+    private readonly MemoryMappedViewAccessor _indexAccessor;
+    private readonly MemoryMappedViewAccessor _stringAccessor;
+    private readonly FileSystemWatcher _assemblyWatcher;
+    private readonly ReaderWriterLockSlim _indexLock;
+    
+    // Index structure in memory:
+    // [Header: 64 bytes]
+    // [Index entries: N * sizeof(AssemblyIndexEntry)]
+    // [String data: Variable length]
+    
+    private const string IndexFileName = "assembly_index.dat";
+    private const int HeaderSize = 64;
+    private const int MaxAssemblies = 10000;
+    
+    public MemoryMappedAssemblyIndex()
+    {
+        _indexLock = new ReaderWriterLockSlim();
+        
+        var indexPath = Path.Combine(Path.GetTempPath(), IndexFileName);
+        var fileSize = HeaderSize + 
+                      (MaxAssemblies * Marshal.SizeOf<AssemblyIndexEntry>()) + 
+                      (MaxAssemblies * 1024); // Avg 1KB per assembly strings
+        
+        // Create or open memory-mapped file
+        _indexFile = MemoryMappedFile.CreateFromFile(
+            indexPath,
+            FileMode.OpenOrCreate,
+            "AssemblyIndex",
+            fileSize,
+            MemoryMappedFileAccess.ReadWrite);
+        
+        _headerAccessor = _indexFile.CreateViewAccessor(0, HeaderSize);
+        _indexAccessor = _indexFile.CreateViewAccessor(
+            HeaderSize, 
+            MaxAssemblies * Marshal.SizeOf<AssemblyIndexEntry>());
+        _stringAccessor = _indexFile.CreateViewAccessor(
+            HeaderSize + (MaxAssemblies * Marshal.SizeOf<AssemblyIndexEntry>()), 
+            0);
+        
+        InitializeOrValidateIndex();
+        SetupFileWatcher();
+    }
+    
+    public Assembly FindAssembly(AssemblyName assemblyName)
+    {
+        _indexLock.EnterReadLock();
+        try
+        {
+            // Binary search in sorted index
+            var entryIndex = BinarySearchAssembly(assemblyName);
+            if (entryIndex >= 0)
+            {
+                var entry = ReadIndexEntry(entryIndex);
+                var location = ReadString(_stringAccessor, entry.LocationOffset, entry.LocationLength);
+                
+                // Verify assembly still exists and matches
+                if (File.Exists(location))
+                {
+                    return Assembly.LoadFrom(location);
+                }
+            }
+            
+            return null;
+        }
+        finally
+        {
+            _indexLock.ExitReadLock();
+        }
+    }
+    
+    private int BinarySearchAssembly(AssemblyName target)
+    {
+        var count = _headerAccessor.ReadInt32(0);
+        var left = 0;
+        var right = count - 1;
+        
+        while (left <= right)
+        {
+            var mid = (left + right) / 2;
+            var entry = ReadIndexEntry(mid);
+            
+            var fullName = ReadString(_stringAccessor, entry.FullNameOffset, entry.FullNameLength);
+            var midName = new AssemblyName(fullName);
+            
+            var comparison = CompareAssemblyNames(target, midName);
+            if (comparison == 0)
+            {
+                return mid;
+            }
+            else if (comparison < 0)
+            {
+                right = mid - 1;
+            }
+            else
+            {
+                left = mid + 1;
+            }
+        }
+        
+        return -1;
+    }
+    
+    private void RebuildIndex()
+    {
+        _indexLock.EnterWriteLock();
+        try
+        {
+            var assemblies = AssemblyLoadContext.All
+                .SelectMany(c => c.Assemblies)
+                .Where(a => !a.IsDynamic && !a.IsCollectible)
+                .OrderBy(a => a.FullName)
+                .ToList();
+            
+            var stringOffset = 0L;
+            var entries = new List<AssemblyIndexEntry>();
+            
+            using (var stringStream = new MemoryStream())
+            using (var writer = new BinaryWriter(stringStream))
+            {
+                foreach (var assembly in assemblies)
+                {
+                    var fullName = assembly.FullName;
+                    var simpleName = assembly.GetName().Name;
+                    var location = assembly.Location ?? string.Empty;
+                    
+                    var entry = new AssemblyIndexEntry
+                    {
+                        FullNameOffset = stringOffset,
+                        FullNameLength = Encoding.UTF8.GetByteCount(fullName),
+                        SimpleNameOffset = stringOffset + entry.FullNameLength,
+                        SimpleNameLength = Encoding.UTF8.GetByteCount(simpleName),
+                        LocationOffset = entry.SimpleNameOffset + entry.SimpleNameLength,
+                        LocationLength = Encoding.UTF8.GetByteCount(location),
+                        VersionTicks = assembly.GetName().Version?.ToBinary() ?? 0,
+                        Flags = 0
+                    };
+                    
+                    entries.Add(entry);
+                    
+                    writer.Write(Encoding.UTF8.GetBytes(fullName));
+                    writer.Write(Encoding.UTF8.GetBytes(simpleName));
+                    writer.Write(Encoding.UTF8.GetBytes(location));
+                    
+                    stringOffset += entry.FullNameLength + entry.SimpleNameLength + entry.LocationLength;
+                }
+                
+                // Write header
+                _headerAccessor.Write(0, entries.Count);
+                _headerAccessor.Write(8, DateTime.UtcNow.Ticks);
+                
+                // Write index entries
+                for (int i = 0; i < entries.Count; i++)
+                {
+                    WriteIndexEntry(i, entries[i]);
+                }
+                
+                // Write string data
+                var stringData = stringStream.ToArray();
+                _stringAccessor.WriteArray(0, stringData, 0, stringData.Length);
+            }
+        }
+        finally
+        {
+            _indexLock.ExitWriteLock();
+        }
+    }
+    
+    private void SetupFileWatcher()
+    {
+        // Watch for new assemblies being loaded
+        var appPath = AppDomain.CurrentDomain.BaseDirectory;
+        _assemblyWatcher = new FileSystemWatcher(appPath, "*.dll")
+        {
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
+            IncludeSubdirectories = true
+        };
+        
+        _assemblyWatcher.Changed += (s, e) => ScheduleIndexRebuild();
+        _assemblyWatcher.Created += (s, e) => ScheduleIndexRebuild();
+        _assemblyWatcher.EnableRaisingEvents = true;
+    }
+}
+```
+
+### Benefits
+
+1. **Zero allocation**: No array creation for assembly enumeration
+2. **Persistent cache**: Index survives application restarts
+3. **Memory efficiency**: Shared memory across app domains
+4. **O(log n) lookup**: Binary search in sorted index
+5. **Dynamic updates**: Automatic index updates when assemblies change
+
+### Estimated Performance Impact
+
+- **Memory allocation**: 90% reduction in GC pressure
+- **Lookup performance**: O(log n) vs O(n), 10-50x faster for large assembly counts
+- **Startup time**: 80% reduction when index is already built
+- **Memory usage**: 50% reduction due to shared memory model

--- a/src/UiPath.Workflow.Runtime/Expressions/Optimization5.md
+++ b/src/UiPath.Workflow.Runtime/Expressions/Optimization5.md
@@ -1,0 +1,259 @@
+# Optimization 5: Specialized Fast Paths for Common Assemblies
+
+## Problem
+
+The current implementation treats all assembly lookups equally, but in practice:
+
+1. **80/20 rule**: A small set of assemblies (System.*, mscorlib) are requested most frequently
+2. **Known assemblies**: Framework assemblies have predictable locations and versions
+3. **Startup overhead**: Common assemblies are looked up repeatedly during application initialization
+4. **Cache misses**: Even cached lookups have overhead for dictionary access
+
+## Solution
+
+Implement specialized fast paths for the most common assembly requests:
+
+1. **Static lookup table**: Pre-computed lookups for framework assemblies
+2. **Inline caching**: Thread-local caches for hot paths
+3. **Assembly fingerprinting**: Quick validation without full comparison
+4. **Specialized equality**: Optimized comparison for common patterns
+
+### Implementation Details
+
+```csharp
+public static class AssemblyReferenceFastPath
+{
+    // Pre-computed framework assemblies
+    private static readonly Dictionary<string, Assembly> FrameworkAssemblies;
+    private static readonly HashSet<string> FrameworkAssemblyNames;
+    
+    // Thread-local inline cache for hot assemblies
+    [ThreadStatic]
+    private static InlineCache t_inlineCache;
+    
+    // Bloom filter for negative caching
+    private static readonly BloomFilter<string> NonExistentAssemblies;
+    
+    private struct InlineCache
+    {
+        // Most recent 4 assemblies accessed by this thread
+        public AssemblyName Name1, Name2, Name3, Name4;
+        public Assembly Assembly1, Assembly2, Assembly3, Assembly4;
+        public int HitCount;
+        
+        public bool TryGet(AssemblyName name, out Assembly assembly)
+        {
+            // Unrolled loop for maximum performance
+            if (FastEquals(name, Name1)) { assembly = Assembly1; HitCount++; return true; }
+            if (FastEquals(name, Name2)) { assembly = Assembly2; HitCount++; return true; }
+            if (FastEquals(name, Name3)) { assembly = Assembly3; HitCount++; return true; }
+            if (FastEquals(name, Name4)) { assembly = Assembly4; HitCount++; return true; }
+            
+            assembly = null;
+            return false;
+        }
+        
+        public void Add(AssemblyName name, Assembly assembly)
+        {
+            // LRU replacement
+            Name4 = Name3; Assembly4 = Assembly3;
+            Name3 = Name2; Assembly3 = Assembly2;
+            Name2 = Name1; Assembly2 = Assembly1;
+            Name1 = name; Assembly1 = assembly;
+        }
+    }
+    
+    static AssemblyReferenceFastPath()
+    {
+        // Pre-load all framework assemblies
+        FrameworkAssemblies = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
+        FrameworkAssemblyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        
+        var frameworkAssemblies = new[]
+        {
+            "mscorlib",
+            "System",
+            "System.Core",
+            "System.Runtime",
+            "System.Collections",
+            "System.Linq",
+            "System.Threading.Tasks",
+            "System.IO",
+            "System.Text.RegularExpressions",
+            "System.Reflection",
+            "System.Diagnostics.Debug",
+            "System.Runtime.Extensions",
+            "System.ObjectModel",
+            "System.ComponentModel",
+            "System.Xml",
+            "System.Xml.Linq",
+            "Microsoft.CSharp"
+        };
+        
+        foreach (var name in frameworkAssemblies)
+        {
+            try
+            {
+                var assembly = Assembly.Load(name);
+                FrameworkAssemblies[name] = assembly;
+                FrameworkAssemblies[assembly.FullName] = assembly;
+                FrameworkAssemblyNames.Add(name);
+                FrameworkAssemblyNames.Add(assembly.FullName);
+            }
+            catch
+            {
+                // Ignore assemblies that don't exist in this runtime
+            }
+        }
+        
+        NonExistentAssemblies = new BloomFilter<string>(10000, 0.01);
+    }
+    
+    public static bool TryGetAssemblyFast(AssemblyName assemblyName, out Assembly assembly)
+    {
+        // Level 0: Inline thread-local cache
+        if (t_inlineCache.TryGet(assemblyName, out assembly))
+        {
+            return true;
+        }
+        
+        // Level 1: Framework assembly fast path
+        var simpleName = assemblyName.Name;
+        if (FrameworkAssemblyNames.Contains(simpleName))
+        {
+            if (FrameworkAssemblies.TryGetValue(simpleName, out assembly))
+            {
+                // Verify version compatibility if specified
+                if (assemblyName.Version == null || 
+                    assembly.GetName().Version >= assemblyName.Version)
+                {
+                    t_inlineCache.Add(assemblyName, assembly);
+                    return true;
+                }
+            }
+        }
+        
+        // Level 2: Check negative cache
+        var fullName = assemblyName.FullName;
+        if (NonExistentAssemblies.Contains(fullName))
+        {
+            assembly = null;
+            return true; // Known to not exist
+        }
+        
+        // Fall back to regular cache
+        return false;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool FastEquals(AssemblyName a, AssemblyName b)
+    {
+        // Fast path for reference equality
+        if (ReferenceEquals(a, b)) return true;
+        if (a == null || b == null) return false;
+        
+        // Quick name comparison first (most likely to differ)
+        if (!string.Equals(a.Name, b.Name, StringComparison.OrdinalIgnoreCase))
+            return false;
+        
+        // Only check version if specified in 'a'
+        if (a.Version != null && !a.Version.Equals(b.Version))
+            return false;
+        
+        // Skip culture and public key token for fast path
+        // (framework assemblies typically don't vary on these)
+        return true;
+    }
+    
+    // Optimized assembly name comparer using fingerprinting
+    public class FastAssemblyNameComparer : IEqualityComparer<AssemblyName>
+    {
+        public bool Equals(AssemblyName x, AssemblyName y)
+        {
+            return FastEquals(x, y);
+        }
+        
+        public int GetHashCode(AssemblyName obj)
+        {
+            // Fast hash combining name and version
+            unchecked
+            {
+                var hash = obj.Name?.GetHashCode(StringComparison.OrdinalIgnoreCase) ?? 0;
+                if (obj.Version != null)
+                {
+                    hash = (hash * 397) ^ obj.Version.GetHashCode();
+                }
+                return hash;
+            }
+        }
+    }
+}
+
+// Integration with main class
+public static Assembly GetAssembly(AssemblyName assemblyName)
+{
+    // Try fast path first
+    if (AssemblyReferenceFastPath.TryGetAssemblyFast(assemblyName, out var assembly))
+    {
+        return assembly;
+    }
+    
+    // Fall back to regular implementation
+    return GetAssemblyRegular(assemblyName);
+}
+```
+
+### Additional Optimization: Assembly Fingerprinting
+
+```csharp
+public readonly struct AssemblyFingerprint : IEquatable<AssemblyFingerprint>
+{
+    private readonly ulong _hash;
+    private readonly int _version;
+    
+    public AssemblyFingerprint(AssemblyName assemblyName)
+    {
+        // Compute a fast 64-bit hash of the assembly name
+        var name = assemblyName.Name ?? string.Empty;
+        _hash = ComputeHash(name);
+        _version = assemblyName.Version?.GetHashCode() ?? 0;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong ComputeHash(string s)
+    {
+        // FNV-1a hash for speed
+        const ulong FnvPrime = 0x00000100000001B3;
+        const ulong FnvOffsetBasis = 0xCBF29CE484222325;
+        
+        ulong hash = FnvOffsetBasis;
+        foreach (char c in s)
+        {
+            hash ^= char.ToLowerInvariant(c);
+            hash *= FnvPrime;
+        }
+        return hash;
+    }
+    
+    public bool Equals(AssemblyFingerprint other)
+    {
+        return _hash == other._hash && _version == other._version;
+    }
+}
+```
+
+### Benefits
+
+1. **Zero-lookup for framework assemblies**: Most common assemblies return immediately
+2. **Thread-local caching**: Eliminates contention for hot assemblies
+3. **Negative caching**: Bloom filter prevents repeated failed lookups
+4. **Optimized comparison**: Faster equality checks for common cases
+5. **Memory efficiency**: Minimal overhead for fast paths
+
+### Estimated Performance Impact
+
+- **Framework assemblies**: 100-1000x faster (direct field access vs dictionary lookup)
+- **Thread-local hits**: 50-100x faster (no synchronization needed)
+- **Negative lookups**: 10x faster with bloom filter
+- **Overall improvement**: 70-90% of requests served by fast path
+- **Memory overhead**: < 1MB for all optimization structures


### PR DESCRIPTION
This method is super 'hot' (got ~400k calls only during the pre-processing of a large project), It's heavily used during `CacheMetadata` so it impacts document loading, pre-processing, validation and compilation.