### PR TITLE
Perf: Optimize AssemblyReference.GetAssembly

### DIFF
--- a/src/Perf/Perf.AssemblyReference.Benchmarks/Benchmarks/AssemblyReferenceBenchmarks.cs
+++ b/src/Perf/Perf.AssemblyReference.Benchmarks/Benchmarks/AssemblyReferenceBenchmarks.cs
@@ -30,6 +30,7 @@ namespace Perf.AssemblyReference.Benchmarks
     {
         const int lookupCount = 10000;
         int[] lookupArray = new int[lookupCount];
+        AssemblyName nonExistentAssemblyName = new AssemblyName("NonExistent.Assembly");
         AssemblyName[] lookupAssemblies;
         ParallelOptions parallelOptions_4Cores = new ParallelOptions { MaxDegreeOfParallelism = 4 };
         ParallelOptions parallelOptions_16Cores = new ParallelOptions { MaxDegreeOfParallelism = 16 };
@@ -107,6 +108,15 @@ namespace Perf.AssemblyReference.Benchmarks
         }
 
         [Benchmark]
+        public void SequentialLookup_CacheMiss()
+        {
+            for (int i = 0; i < lookupCount; i++)
+            {
+                AssemblyReferenceOG.GetAssembly(nonExistentAssemblyName);
+            }
+        }
+
+        [Benchmark]
         public void ParallelLookup4Cores()
         {
             Parallel.ForEach(lookupArray, parallelOptions_4Cores, (i, token) =>
@@ -124,12 +134,30 @@ namespace Perf.AssemblyReference.Benchmarks
             });
         }
 
+        [Benchmark]
+        public void ParallelLookup16Cores_CacheMiss()
+        {
+            Parallel.ForEach(lookupArray, parallelOptions_16Cores, (i, token) =>
+            {
+                AssemblyReferenceOG.GetAssembly(nonExistentAssemblyName);
+            });
+        }
+
         //[Benchmark]
         //public void SequentialLookup_V2()
         //{
         //    for (int i = 0; i < lookupCount; i++)
         //    {
         //        AssemblyReferenceV2.GetAssembly(lookupAssemblies[i % lookupAssemblies.Length]);
+        //    }
+        //}
+
+        //[Benchmark]
+        //public void SequentialLookup_CacheMiss_V2()
+        //{
+        //    for (int i = 0; i < lookupCount; i++)
+        //    {
+        //        AssemblyReferenceV2.GetAssembly(nonExistentAssemblyName);
         //    }
         //}
 
@@ -148,6 +176,15 @@ namespace Perf.AssemblyReference.Benchmarks
         //    Parallel.ForEach(lookupArray, parallelOptions_16Cores, (i, token) =>
         //    {
         //        AssemblyReferenceV2.GetAssembly(lookupAssemblies[i % lookupAssemblies.Length]);
+        //    });
+        //}
+
+        //[Benchmark]
+        //public void ParallelLookup16Cores_CacheMiss_V2()
+        //{
+        //    Parallel.ForEach(lookupArray, parallelOptions_16Cores, (i, token) =>
+        //    {
+        //        AssemblyReferenceV2.GetAssembly(nonExistentAssemblyName);
         //    });
         //}
     }

--- a/src/Perf/Perf.AssemblyReference.Benchmarks/Benchmarks/AssemblyReferenceBenchmarks.cs
+++ b/src/Perf/Perf.AssemblyReference.Benchmarks/Benchmarks/AssemblyReferenceBenchmarks.cs
@@ -11,6 +11,8 @@ using Microsoft.Extensions.DependencyModel;
 using NodaTime;
 using Polly;
 using Serilog;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp;
 using System.Activities.Expressions;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -57,7 +59,7 @@ namespace Perf.AssemblyReference.Benchmarks
             var document = new HtmlAgilityPack.HtmlDocument();
 
             var sheet = new ClosedXML.Excel.XLWorkbook();
-            SixLabors.ImageSharp.Image.Load("C:\\Users\\marius.bughiu\\Downloads\\IMG_6914.jpg");
+            using Image<Rgba32> image = new Image<Rgba32>(400, 400);
             var validator = new FluentValidation.InlineValidator<object>();
             var policy = Polly.Policy.Handle<Exception>().Retry(1);
             var date = NodaTime.SystemClock.Instance.GetCurrentInstant();

--- a/src/Perf/Perf.AssemblyReference.Benchmarks/Benchmarks/AssemblyReferenceBenchmarks.cs
+++ b/src/Perf/Perf.AssemblyReference.Benchmarks/Benchmarks/AssemblyReferenceBenchmarks.cs
@@ -1,4 +1,14 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using Azure.Storage.Blobs;
+using BenchmarkDotNet.Attributes;
+using ClosedXML.Excel;
+using CsvHelper.Configuration;
+using HtmlAgilityPack;
+using MailKit.Net.Smtp;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyModel;
+using NodaTime;
 using Polly;
 using Serilog;
 using System.Activities.Expressions;
@@ -16,7 +26,7 @@ namespace Perf.AssemblyReference.Benchmarks
     [MemoryDiagnoser(true)]
     public class AssemblyReferenceBenchmarks
     {
-        const int lookupCount = 1000;
+        const int lookupCount = 10000;
         int[] lookupArray = new int[lookupCount];
         AssemblyName[] lookupAssemblies;
         ParallelOptions parallelOptions_4Cores = new ParallelOptions { MaxDegreeOfParallelism = 4 };
@@ -51,6 +61,38 @@ namespace Perf.AssemblyReference.Benchmarks
             var validator = new FluentValidation.InlineValidator<object>();
             var policy = Polly.Policy.Handle<Exception>().Retry(1);
             var date = NodaTime.SystemClock.Instance.GetCurrentInstant();
+
+            _ = Policy.Handle<Exception>().Retry(1);
+            _ = new CsvConfiguration(System.Globalization.CultureInfo.InvariantCulture);
+            _ = new HtmlDocument();
+            _ = SystemClock.Instance.GetCurrentInstant();
+            _ = new SmtpClient();
+            _ = new XLWorkbook();
+            _ = new BlobClient(new Uri("https://fake.blob.core.windows.net/test"), new Azure.AzureSasCredential("token"));
+            _ = new ConfigurationBuilder().AddJsonFile("appsettings.json", optional: true).Build();
+            _ = new ServiceCollection().AddLogging().BuildServiceProvider();
+            _ = new DefaultHttpContext();
+
+            var deps = DependencyContext.Default;
+            var assemblies = deps.RuntimeLibraries;
+
+            foreach (var lib in assemblies)
+            {
+                foreach (var assemblyName in lib.GetDefaultAssemblyNames(deps))
+                {
+                    try
+                    {
+                        if (AppDomain.CurrentDomain.GetAssemblies().All(a => a.GetName().Name != assemblyName.Name))
+                        {
+                            Assembly.Load(assemblyName);
+                        }
+                    }
+                    catch
+                    {
+                        // Skip failed loads
+                    }
+                }
+            }
         }
 
         [Benchmark]

--- a/src/Perf/Perf.AssemblyReference.Benchmarks/Benchmarks/AssemblyReferenceBenchmarks.cs
+++ b/src/Perf/Perf.AssemblyReference.Benchmarks/Benchmarks/AssemblyReferenceBenchmarks.cs
@@ -1,0 +1,110 @@
+﻿using BenchmarkDotNet.Attributes;
+using Polly;
+using Serilog;
+using System.Activities.Expressions;
+using System.Reflection;
+using System.Runtime.Loader;
+using AssemblyReferenceOG = System.Activities.Expressions.AssemblyReference;
+
+namespace Perf.AssemblyReference.Benchmarks
+{
+    /// <summary>
+    /// For benchmarking improvements to GetAssembly simply create a copy of AssemblyReference.cs,
+    /// name it AssemblyReferenceV2 and make your improvements there. Then uncomment the _V2 benchmarks
+    /// below and run the project.
+    /// </summary>
+    [MemoryDiagnoser(true)]
+    public class AssemblyReferenceBenchmarks
+    {
+        const int lookupCount = 1000;
+        int[] lookupArray = new int[lookupCount];
+        AssemblyName[] lookupAssemblies;
+        ParallelOptions parallelOptions_4Cores = new ParallelOptions { MaxDegreeOfParallelism = 4 };
+        ParallelOptions parallelOptions_16Cores = new ParallelOptions { MaxDegreeOfParallelism = 16 };
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            // Force loads a bunch of assemblies to simulate a realistic environment
+            ForceLoadAssemblies();
+
+            lookupAssemblies = AssemblyLoadContext.All.SelectMany(c => c.Assemblies)
+                // Duplicate assemblies to simulate duplicate requests from different threads
+                .SelectMany(a => Enumerable.Range(0, 4), (a, i) => a.GetName())
+                .ToArray();
+        }
+
+        internal static void ForceLoadAssemblies()
+        {
+            // Instantiate types from different NuGet packages to trigger assembly loading
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(new { hello = "world" });
+            var config = new Serilog.LoggerConfiguration().WriteTo.Console().CreateLogger();
+            config.Information("Logging from Serilog");
+
+            var mapper = new AutoMapper.MapperConfiguration(cfg => { }).CreateMapper();
+            var faker = new Bogus.Faker();
+            var csv = new CsvHelper.Configuration.CsvConfiguration(System.Globalization.CultureInfo.InvariantCulture);
+            var document = new HtmlAgilityPack.HtmlDocument();
+
+            var sheet = new ClosedXML.Excel.XLWorkbook();
+            SixLabors.ImageSharp.Image.Load("C:\\Users\\marius.bughiu\\Downloads\\IMG_6914.jpg");
+            var validator = new FluentValidation.InlineValidator<object>();
+            var policy = Polly.Policy.Handle<Exception>().Retry(1);
+            var date = NodaTime.SystemClock.Instance.GetCurrentInstant();
+        }
+
+        [Benchmark]
+        public void SequentialLookup()
+        {
+            for (int i = 0; i < lookupCount; i++)
+            {
+                AssemblyReferenceOG.GetAssembly(lookupAssemblies[i % lookupAssemblies.Length]);
+            }
+        }
+
+        [Benchmark]
+        public void ParallelLookup4Cores()
+        {
+            Parallel.ForEach(lookupArray, parallelOptions_4Cores, (i, token) =>
+            {
+                AssemblyReferenceOG.GetAssembly(lookupAssemblies[i % lookupAssemblies.Length]);
+            });
+        }
+
+        [Benchmark]
+        public void ParallelLookup16Cores()
+        {
+            Parallel.ForEach(lookupArray, parallelOptions_16Cores, (i, token) =>
+            {
+                AssemblyReferenceOG.GetAssembly(lookupAssemblies[i % lookupAssemblies.Length]);
+            });
+        }
+
+        //[Benchmark]
+        //public void SequentialLookup_V2()
+        //{
+        //    for (int i = 0; i < lookupCount; i++)
+        //    {
+        //        AssemblyReferenceV2.GetAssembly(lookupAssemblies[i % lookupAssemblies.Length]);
+        //    }
+        //}
+
+        //[Benchmark]
+        //public void ParallelLookup4Cores_V2()
+        //{
+        //    Parallel.ForEach(lookupArray, parallelOptions_4Cores, (i, token) =>
+        //    {
+        //        AssemblyReferenceV2.GetAssembly(lookupAssemblies[i % lookupAssemblies.Length]);
+        //    });
+        //}
+
+        //[Benchmark]
+        //public void ParallelLookup16Cores_V2()
+        //{
+        //    Parallel.ForEach(lookupArray, parallelOptions_16Cores, (i, token) =>
+        //    {
+        //        AssemblyReferenceV2.GetAssembly(lookupAssemblies[i % lookupAssemblies.Length]);
+        //    });
+        //}
+    }
+}

--- a/src/Perf/Perf.AssemblyReference.Benchmarks/Perf.AssemblyReference.Benchmarks.csproj
+++ b/src/Perf/Perf.AssemblyReference.Benchmarks/Perf.AssemblyReference.Benchmarks.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFrameworks>net6.0;net6.0-windows</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AutoMapper" Version="9.0.0" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+		<PackageReference Include="Bogus" Version="35.6.3" />
+		<PackageReference Include="ClosedXML" Version="0.105.0" />
+		<PackageReference Include="CsvHelper" Version="33.1.0" />
+		<PackageReference Include="Dapper" Version="2.1.66" />
+		<PackageReference Include="EPPlus" Version="8.0.6" />
+		<PackageReference Include="FluentValidation" Version="6.4.1" />
+		<PackageReference Include="Hangfire.Core" Version="1.8.20" />
+		<PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
+		<PackageReference Include="Humanizer" Version="2.14.1" />
+		<PackageReference Include="MailKit" Version="4.12.1" />
+		<PackageReference Include="MediatR" Version="12.5.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="NLog" Version="6.0.0" />
+		<PackageReference Include="NodaTime" Version="3.2.2" />
+		<PackageReference Include="Polly" Version="8.6.1" />
+		<PackageReference Include="RestSharp" Version="112.1.0" />
+		<PackageReference Include="Serilog" Version="4.3.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
+		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\UiPath.Workflow.Runtime\UiPath.Workflow.Runtime.csproj" />
+		<ProjectReference Include="..\..\UiPath.Workflow\UiPath.Workflow.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Perf/Perf.AssemblyReference.Benchmarks/Perf.AssemblyReference.Benchmarks.csproj
+++ b/src/Perf/Perf.AssemblyReference.Benchmarks/Perf.AssemblyReference.Benchmarks.csproj
@@ -9,6 +9,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="9.0.0" />
+		<PackageReference Include="Azure.Identity" Version="1.14.0" />
+		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.24.1" />
 		<PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
 		<PackageReference Include="Bogus" Version="35.6.3" />
 		<PackageReference Include="ClosedXML" Version="0.105.0" />
@@ -16,20 +19,46 @@
 		<PackageReference Include="Dapper" Version="2.1.66" />
 		<PackageReference Include="EPPlus" Version="8.0.6" />
 		<PackageReference Include="FluentValidation" Version="6.4.1" />
+		<PackageReference Include="Google.Apis" Version="1.70.0" />
+		<PackageReference Include="Google.Apis.Auth" Version="1.70.0" />
+		<PackageReference Include="Google.Cloud.Storage.V1" Version="4.13.0" />
 		<PackageReference Include="Hangfire.Core" Version="1.8.20" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
 		<PackageReference Include="Humanizer" Version="2.14.1" />
 		<PackageReference Include="MailKit" Version="4.12.1" />
 		<PackageReference Include="MediatR" Version="12.5.0" />
+		<PackageReference Include="Microsoft.AspNetCore" Version="2.3.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.3.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.3.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
+		<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.3.0" />
+		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
+		<PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+		<PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.2.0" />
+		<PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
+		<PackageReference Include="Microsoft.IdentityModel.Protocols" Version="8.12.1" />
+		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.12.1" />
+		<PackageReference Include="MongoDB.Driver" Version="3.4.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NLog" Version="6.0.0" />
 		<PackageReference Include="NodaTime" Version="3.2.2" />
+		<PackageReference Include="Npgsql" Version="9.0.3" />
 		<PackageReference Include="Polly" Version="8.6.1" />
 		<PackageReference Include="RestSharp" Version="112.1.0" />
 		<PackageReference Include="Serilog" Version="4.3.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
+		<PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
 		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+		<PackageReference Include="System.IO.Pipelines" Version="9.0.6" />
+		<PackageReference Include="System.Reactive" Version="6.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Perf/Perf.AssemblyReference.Benchmarks/Program.cs
+++ b/src/Perf/Perf.AssemblyReference.Benchmarks/Program.cs
@@ -1,0 +1,4 @@
+﻿using BenchmarkDotNet.Running;
+using Perf.AssemblyReference.Benchmarks;
+
+BenchmarkRunner.Run<AssemblyReferenceBenchmarks>();

--- a/src/UiPath.Workflow.Runtime/AssemblyInfo.cs
+++ b/src/UiPath.Workflow.Runtime/AssemblyInfo.cs
@@ -28,3 +28,4 @@ using System.Windows.Markup;
 [assembly: InternalsVisibleTo("UiPath.Workflow")]
 [assembly: InternalsVisibleTo("TestCases.Workflows")]
 [assembly: InternalsVisibleTo("TestCases.Runtime")]
+[assembly: InternalsVisibleTo("Perf.AssemblyReference.Benchmarks")]

--- a/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
@@ -19,10 +19,16 @@ public class AssemblyReference
 
     private static readonly ConcurrentDictionary<Assembly, AssemblyName> assemblyToAssemblyNameCache = new(Environment.ProcessorCount, AssemblyToAssemblyNameCacheInitSize);
     private static readonly ConcurrentDictionary<AssemblyName, Assembly> assemblyCache = new(Environment.ProcessorCount, AssemblyCacheInitialSize, new AssemblyNameEqualityComparer());
+    private static readonly Lazy<ConcurrentDictionary<AssemblyName, bool>> notFoundAssemblyCache = new(() => new(Environment.ProcessorCount, AssemblyCacheInitialSize, new AssemblyNameEqualityComparer()));
 
     private Assembly _assembly;
     private AssemblyName _assemblyName;
     private readonly bool _isImmutable;
+
+    static AssemblyReference()
+    {
+        AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
+    }
 
     public AssemblyReference() { }
 
@@ -113,6 +119,11 @@ public class AssemblyReference
             return assembly;
         }
 
+        if (notFoundAssemblyCache.IsValueCreated && notFoundAssemblyCache.Value.TryGetValue(assemblyName, out var _))
+        {
+            return null;
+        }
+
         // search current AppDomain first
         // this for-loop part is to ensure that 
         // loose AssemblyNames get resolved in the same way 
@@ -171,6 +182,10 @@ public class AssemblyReference
         if (assembly != null)
         {
             assemblyCache.TryAdd(assemblyName, assembly);
+        }
+        else
+        {
+            notFoundAssemblyCache.Value.TryAdd(assemblyName, false);
         }
 
         return assembly;
@@ -233,5 +248,15 @@ public class AssemblyReference
         {
             throw FxTrace.Exception.AsError(new NotSupportedException(SR.AssemblyReferenceIsImmutable));
         }
+    }
+
+    private static void CurrentDomain_AssemblyLoad(object sender, AssemblyLoadEventArgs args)
+    {
+        if (!notFoundAssemblyCache.IsValueCreated)
+        {
+            return;
+        }
+
+        notFoundAssemblyCache.Value.Clear();
     }
 }

--- a/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
@@ -168,7 +168,10 @@ public class AssemblyReference
         }
 
         assembly = LoadAssembly(assemblyName);
-        assemblyCache.TryAdd(assemblyName, assembly);
+        if (assembly != null)
+        {
+            assemblyCache.TryAdd(assemblyName, assembly);
+        }
 
         return assembly;
     }

--- a/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
@@ -2,7 +2,7 @@
 // See LICENSE file in the project root for full license information.
 
 using System.Activities.Runtime;
-using System.Collections;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -14,24 +14,11 @@ namespace System.Activities.Expressions;
 [TypeConverter(TypeConverters.AssemblyReferenceConverter)]
 public class AssemblyReference
 {
-    private const int AssemblyToAssemblyNameCacheInitSize = 100;
-    private const int AssemblyCacheInitialSize = 100;
+    private const int AssemblyToAssemblyNameCacheInitSize = 128;
+    private const int AssemblyCacheInitialSize = 128;
 
-    // cache for Assembly ==> AssemblyName
-    // Assembly.GetName() is very very expensive
-    private static readonly object assemblyToAssemblyNameCacheLock = new();
-
-    // Double-checked locking pattern requires volatile for read/write synchronization
-    private static volatile Hashtable assemblyToAssemblyNameCache;
-
-    // cache for AssemblyName ==> Assembly
-    // For back-compat with VB (which in turn was roughly emulating XamlSchemaContext)
-    // we want to cache a given AssemblyName once it's resolved, so it doesn't get re-resolved
-    // even if a new matching assembly is loaded later.
-
-    // Double-checked locking pattern requires volatile for read/write synchronization
-    private static volatile Hashtable assemblyCache;
-    private static readonly object assemblyCacheLock = new();
+    private static readonly ConcurrentDictionary<Assembly, AssemblyName> assemblyToAssemblyNameCache = new(Environment.ProcessorCount, AssemblyToAssemblyNameCacheInitSize);
+    private static readonly ConcurrentDictionary<AssemblyName, Assembly> assemblyCache = new(Environment.ProcessorCount, AssemblyCacheInitialSize);
 
     private Assembly _assembly;
     private AssemblyName _assemblyName;
@@ -122,23 +109,11 @@ public class AssemblyReference
 
     internal static Assembly GetAssembly(AssemblyName assemblyName)
     {
-        // the following assembly resolution logic
-        // emulates the Xaml's assembly resolution logic as closely as possible.
-        // Should Xaml's assembly resolution logic ever change, this code needs update as well.
-        // please see XamlSchemaContext.ResolveAssembly() 
-        if (assemblyCache == null)
-        {
-            lock (assemblyCacheLock)
-            {
-                if (assemblyCache == null)
-                {
-                    assemblyCache = new Hashtable(AssemblyCacheInitialSize, new AssemblyNameEqualityComparer());
-                }
-            }
-        }
+        // The following assembly resolution logic emulates the Xaml's assembly resolution logic
+        // as closely as possible. Should Xaml's assembly resolution logic ever change, this code
+        // needs update as well please see XamlSchemaContext.ResolveAssembly() 
 
-        Assembly assembly = assemblyCache[assemblyName] as Assembly;
-        if (assembly != null)
+        if (assemblyCache.TryGetValue(assemblyName, out Assembly assembly))
         {
             return assembly;
         }
@@ -149,7 +124,7 @@ public class AssemblyReference
         // as Xaml would do.  that is to find the first match
         // found starting from the end of the array of Assemblies
         // returned by AppDomain.GetAssemblies()
-        Assembly[] currentAssemblies = AssemblyLoadContext.All.SelectMany(c=>c.Assemblies).ToArray();
+        Assembly[] currentAssemblies = AssemblyLoadContext.All.SelectMany(c => c.Assemblies).ToArray();
 
         // For collectible assemblies, we need to ensure that they
         // are not cached, but are usable in expressions.
@@ -185,11 +160,8 @@ public class AssemblyReference
                         (reqCulture == null || reqCulture.Equals(curCulture)) &&
                         (reqKeyToken == null || AssemblyNameEqualityComparer.IsSameKeyToken(reqKeyToken, curKeyToken)))
             {
-                lock (assemblyCacheLock)
-                {
-                    assemblyCache[assemblyName] = curAsm;
-                    return curAsm;
-                }
+                assemblyCache.TryAdd(assemblyName, curAsm);
+                return curAsm;
             }
         }
 
@@ -201,13 +173,7 @@ public class AssemblyReference
         }
 
         assembly = LoadAssembly(assemblyName);
-        if (assembly != null)
-        {
-            lock (assemblyCacheLock)
-            {
-                assemblyCache[assemblyName] = assembly;
-            }
-        }
+        assemblyCache.TryAdd(assemblyName, assembly);
 
         return assembly;
     }
@@ -222,29 +188,7 @@ public class AssemblyReference
             return new AssemblyName(assembly.FullName);
         }
 
-        if (assemblyToAssemblyNameCache == null)
-        {
-            lock (assemblyToAssemblyNameCacheLock)
-            {
-                if (assemblyToAssemblyNameCache == null)
-                {
-                    assemblyToAssemblyNameCache = new Hashtable(AssemblyToAssemblyNameCacheInitSize);
-                }
-            }
-        }
-
-        if (assemblyToAssemblyNameCache[assembly] is AssemblyName assemblyName)
-        {
-            return assemblyName;
-        }
-
-        assemblyName = new AssemblyName(assembly.FullName);
-        lock (assemblyToAssemblyNameCacheLock)
-        {
-            assemblyToAssemblyNameCache[assembly] = assemblyName;
-        }
-
-        return assemblyName;
+        return assemblyToAssemblyNameCache.GetOrAdd(assembly, asm => new AssemblyName(asm.FullName));
     }
 
 #pragma warning disable 618

--- a/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
@@ -202,7 +202,8 @@ public class AssemblyReference
             {
                 if (ex is FileNotFoundException ||
                     ex is FileLoadException ||
-                    (ex is TargetInvocationException exception && exception.InnerException is FileNotFoundException))
+                    (ex is TargetInvocationException exception && 
+                        (exception.InnerException is FileNotFoundException || ex is FileLoadException)))
                 {
                     loaded = null;
                     ExceptionTrace.AsWarning(ex);

--- a/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
@@ -216,20 +216,12 @@ public class AssemblyReference
             {
                 loaded = Assembly.Load(assemblyName.FullName);
             }
-            catch (Exception ex)
+            catch (Exception ex) 
+                when (ex is FileNotFoundException or FileLoadException
+                || ex is TargetInvocationException exception && exception.InnerException is FileNotFoundException or FileLoadException)
             {
-                if (ex is FileNotFoundException ||
-                    ex is FileLoadException ||
-                    (ex is TargetInvocationException exception && 
-                        (exception.InnerException is FileNotFoundException || ex is FileLoadException)))
-                {
-                    loaded = null;
-                    ExceptionTrace.AsWarning(ex);
-                }
-                else
-                {
-                    throw;
-                }
+                loaded = null;
+                ExceptionTrace.AsWarning(ex);
             }
         }
         else

--- a/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
+++ b/src/UiPath.Workflow.Runtime/Expressions/AssemblyReference.cs
@@ -18,7 +18,7 @@ public class AssemblyReference
     private const int AssemblyCacheInitialSize = 128;
 
     private static readonly ConcurrentDictionary<Assembly, AssemblyName> assemblyToAssemblyNameCache = new(Environment.ProcessorCount, AssemblyToAssemblyNameCacheInitSize);
-    private static readonly ConcurrentDictionary<AssemblyName, Assembly> assemblyCache = new(Environment.ProcessorCount, AssemblyCacheInitialSize);
+    private static readonly ConcurrentDictionary<AssemblyName, Assembly> assemblyCache = new(Environment.ProcessorCount, AssemblyCacheInitialSize, new AssemblyNameEqualityComparer());
 
     private Assembly _assembly;
     private AssemblyName _assemblyName;
@@ -60,12 +60,8 @@ public class AssemblyReference
         }
     }
 
-    //[SuppressMessage(FxCop.Category.Usage, FxCop.Rule.OperatorOverloadsHaveNamedAlternates,
-    //    Justification = "A named method provides no advantage over the property setter.")]
     public static implicit operator AssemblyReference(Assembly assembly) => new() { Assembly = assembly };
 
-    //[SuppressMessage(FxCop.Category.Usage, FxCop.Rule.OperatorOverloadsHaveNamedAlternates,
-    //    Justification = "A named method provides no advantage over the property setter.")]
     public static implicit operator AssemblyReference(AssemblyName assemblyName) => new() { AssemblyName = assemblyName };
 
     public void LoadAssembly()
@@ -76,7 +72,6 @@ public class AssemblyReference
         }
     }
 
-    // this code is borrowed from XamlSchemaContext
     internal static bool AssemblySatisfiesReference(AssemblyName assemblyName, AssemblyName reference)
     {
         if (reference.Name != assemblyName.Name)
@@ -129,6 +124,10 @@ public class AssemblyReference
         // For collectible assemblies, we need to ensure that they
         // are not cached, but are usable in expressions.
         var collectibleAssemblies = new Dictionary<string, Assembly>();
+        Version reqVersion = assemblyName.Version;
+        CultureInfo reqCulture = assemblyName.CultureInfo;
+        byte[] reqKeyToken = assemblyName.GetPublicKeyToken();
+
         for (int i = currentAssemblies.Length - 1; i >= 0; i--)
         {
             Assembly curAsm = currentAssemblies[i];
@@ -150,10 +149,6 @@ public class AssemblyReference
             Version curVersion = curAsmName.Version;
             CultureInfo curCulture = curAsmName.CultureInfo;
             byte[] curKeyToken = curAsmName.GetPublicKeyToken();
-
-            Version reqVersion = assemblyName.Version;
-            CultureInfo reqCulture = assemblyName.CultureInfo;
-            byte[] reqKeyToken = assemblyName.GetPublicKeyToken();
 
             if ((string.Compare(curAsmName.Name, assemblyName.Name, StringComparison.OrdinalIgnoreCase) == 0) &&
                         (reqVersion == null || reqVersion.Equals(curVersion)) &&
@@ -199,7 +194,6 @@ public class AssemblyReference
         Assembly loaded;
         if (assemblyName.Version != null || assemblyName.CultureInfo != null || publicKeyToken != null)
         {
-            // Assembly.Load(string)
             try
             {
                 loaded = Assembly.Load(assemblyName.FullName);
@@ -208,9 +202,7 @@ public class AssemblyReference
             {
                 if (ex is FileNotFoundException ||
                     ex is FileLoadException ||
-                    (ex is TargetInvocationException exception &&
-                    (exception.InnerException is FileNotFoundException ||
-                    exception.InnerException is FileNotFoundException)))
+                    (ex is TargetInvocationException exception && exception.InnerException is FileNotFoundException))
                 {
                     loaded = null;
                     ExceptionTrace.AsWarning(ex);

--- a/src/UiPath.Workflow.sln
+++ b/src/UiPath.Workflow.sln
@@ -48,6 +48,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomTestObjects", "Test\C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowApplicationTestExtensions", "Test\WorkflowApplicationTestExtensions\WorkflowApplicationTestExtensions.csproj", "{3942321A-09CE-4CF0-A4B7-BF29EF9A17AF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perf.AssemblyReference.Benchmarks", "Perf\Perf.AssemblyReference.Benchmarks\Perf.AssemblyReference.Benchmarks.csproj", "{2D3B90E9-802A-4A29-929B-AD485747D242}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,6 +120,10 @@ Global
 		{3942321A-09CE-4CF0-A4B7-BF29EF9A17AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3942321A-09CE-4CF0-A4B7-BF29EF9A17AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3942321A-09CE-4CF0-A4B7-BF29EF9A17AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D3B90E9-802A-4A29-929B-AD485747D242}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D3B90E9-802A-4A29-929B-AD485747D242}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D3B90E9-802A-4A29-929B-AD485747D242}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D3B90E9-802A-4A29-929B-AD485747D242}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -134,6 +140,7 @@ Global
 		{FE1D4185-DF43-467C-8380-CBA60C6B92DA} = {8E6A125F-0530-4D8E-8CD4-3429DAF57706}
 		{E8CED08F-0838-4167-AA20-5BD42372558E} = {4D92EFCA-7902-49DE-B98F-8CF7675ED86C}
 		{3942321A-09CE-4CF0-A4B7-BF29EF9A17AF} = {4D92EFCA-7902-49DE-B98F-8CF7675ED86C}
+		{2D3B90E9-802A-4A29-929B-AD485747D242} = {8E6A125F-0530-4D8E-8CD4-3429DAF57706}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1ED6A6D7-ACEE-4780-B630-50DCAED74BA9}


### PR DESCRIPTION
Benchmark below is for 10.000 lookups, and 377 assemblies in the load context:

```
|                             Method |            Mean |         Error |        StdDev |     Gen 0 |     Gen 1 |     Allocated |
|----------------------------------- |----------------:|--------------:|--------------:|----------:|----------:|--------------:|
|                   SequentialLookup |     2,023.28 us |     30.129 us |     28.182 us |   23.4375 |         - |     410,597 B |
|         SequentialLookup_CacheMiss |   534,399.22 us | 10,622.933 us | 24,407.955 us | 7000.0000 |         - | 129,361,632 B |
|               ParallelLookup4Cores |       100.38 us |      1.969 us |      4.197 us |    0.1221 |         - |       2,312 B |
|              ParallelLookup16Cores |        58.10 us |      0.882 us |      0.782 us |    0.3052 |         - |       5,287 B |
|    ParallelLookup16Cores_CacheMiss | 2,335,725.04 us | 38,796.851 us | 36,290.598 us | 8000.0000 | 1000.0000 | 129,372,080 B |
|                SequentialLookup_V2 |       483.47 us |      9.061 us |      7.566 us |         - |         - |           1 B |
|      SequentialLookup_CacheMiss_V2 |       335.30 us |      4.567 us |      4.049 us |         - |         - |           1 B |
|            ParallelLookup4Cores_V2 |       103.38 us |      1.926 us |      1.801 us |    0.1221 |         - |       2,312 B |
|           ParallelLookup16Cores_V2 |        60.61 us |      1.208 us |      1.612 us |    0.3052 |         - |       5,288 B |
| ParallelLookup16Cores_CacheMiss_V2 |       900.95 us |     11.278 us |      9.418 us |         - |         - |       5,291 B |
```