### PR TITLE
Reduce memory allocations in GetParents & ProcessActivity

### DIFF
--- a/src/UiPath.Workflow.Runtime/ActivityUtilities.cs
+++ b/src/UiPath.Workflow.Runtime/ActivityUtilities.cs
@@ -658,10 +658,10 @@ internal static class ActivityUtilities
 
             callback?.Invoke(childActivity, parentChain);
 
-            // copy validation errors in ValidationErrors list
+            // Copy validation errors in ValidationErrors list
             if (tempValidationErrors != null)
             {
-                validationErrors ??= new List<ValidationError>();
+                validationErrors ??= new List<ValidationError>(tempValidationErrors.Count);
                 string prefix = ActivityValidationServices.GenerateValidationErrorPrefix(childActivity.Activity, parentChain, options, out Activity source);
 
                 for (int i = 0; i < tempValidationErrors.Count; i++)

--- a/src/UiPath.Workflow.Runtime/Validation/ValidationContext.cs
+++ b/src/UiPath.Workflow.Runtime/Validation/ValidationContext.cs
@@ -26,7 +26,7 @@ public sealed class ValidationContext
 
     internal IEnumerable<Activity> GetParents()
     {
-        List<Activity> parentsList = new();
+        List<Activity> parentsList = new(_parentChain.Count);
 
         for (int i = 0; i < _parentChain.Count; i++)
         {


### PR DESCRIPTION
The following is a WWF trace, but the same applies to CoreWF.

<img width="2559" height="1167" alt="image" src="https://github.com/user-attachments/assets/4db5fefd-3024-4c5c-b1f3-6b0375b8f961" />
