### PR TITLE
Avoid memory allocations when retrieving OverloadGroupNames

### DIFF
--- a/src/UiPath.Workflow.Runtime/RuntimeArgument.cs
+++ b/src/UiPath.Workflow.Runtime/RuntimeArgument.cs
@@ -12,10 +12,13 @@ using Validation;
 public sealed class RuntimeArgument : LocationReference
 {
     private static InternalEvaluationOrderComparer evaluationOrderComparer;
+    private static readonly ReadOnlyCollection<string> emptyOverloadGroups = new(Array.Empty<string>());
+
     private Argument _boundArgument;
     private readonly PropertyDescriptor _bindingProperty;
     private readonly object _bindingPropertyOwner;
     private List<string> _overloadGroupNames;
+    private ReadOnlyCollection<string> _overloadGroupNamesReadOnly;
     private int _cacheId;
     private readonly string _name;
     private uint _nameHash;
@@ -86,8 +89,19 @@ public sealed class RuntimeArgument : LocationReference
     {
         get
         {
-            _overloadGroupNames ??= new List<string>(0);
-            return new ReadOnlyCollection<string>(_overloadGroupNames);
+            if (_overloadGroupNamesReadOnly == null)
+            {
+                if (_overloadGroupNames == null || _overloadGroupNames.Count == 0)
+                {
+                    _overloadGroupNamesReadOnly = emptyOverloadGroups;
+                }
+                else
+                {
+                    _overloadGroupNamesReadOnly = new ReadOnlyCollection<string>(_overloadGroupNames);
+                }
+            }
+
+            return _overloadGroupNamesReadOnly;
         }
     }
 


### PR DESCRIPTION
A new `new ReadOnlyCollection<string>` is created every time the property is accessed. Also, for every object instance, if `_overloadGroupNames` is null, a `new List<string>(0)` is created.

For my test project, this means: 
- 1.2 GB of List<string> allocated
- 1 GB of ReadOnlyCollection<string> allocated

<img width="985" height="80" alt="image" src="https://github.com/user-attachments/assets/f08cabc3-852f-4f8b-9e0a-6fd6be1fa9f3" />
<img width="2282" height="301" alt="image" src="https://github.com/user-attachments/assets/4374ec3e-ca0d-44b9-bb6f-74f8869e1f64" />
<img width="1792" height="332" alt="image" src="https://github.com/user-attachments/assets/fbc42f55-9046-4291-a09a-8fa60018594c" />

Benchmark:

|                Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|---------------------- |----------:|----------:|----------:|-------:|----------:|
|    OverloadGroupNames | 0.8078 ns | 0.0431 ns | 0.0360 ns |      - |         - |
| OverloadGroupNamesOld | 2.8678 ns | 0.1149 ns | 0.1018 ns | 0.0014 |      24 B |

Benchmark code:

```
[MemoryDiagnoser(true)]
    public class OverloadGroupBenchmark
    {
        RuntimeArgument argument;

        [GlobalSetup]
        public void Setup()
        {
            argument = new RuntimeArgument("arg", typeof(object), ArgumentDirection.In, true);
        }

        [Benchmark]
        public ReadOnlyCollection<string> OverloadGroupNames()
        {
            return argument.OverloadGroupNames;
        }

        [Benchmark]
        public ReadOnlyCollection<string> OverloadGroupNamesOld()
        {
            return argument.OverloadGroupNamesOld;
        }
    }
```

