### PR TITLE
WIP Optimize TryGetArgumentDirectionAndType

### DIFF
--- a/src/UiPath.Workflow.Runtime/ActivityUtilities.cs
+++ b/src/UiPath.Workflow.Runtime/ActivityUtilities.cs
@@ -11,6 +11,7 @@ using Expressions;
 using Internals;
 using Runtime;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using Validation;
 
 internal static class ActivityUtilities
@@ -112,6 +113,7 @@ internal static class ActivityUtilities
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetArgumentDirectionAndType(Type propertyType, out ArgumentDirection direction, out Type argumentType)
     {
         direction = ArgumentDirection.In; // default to In

--- a/src/UiPath.Workflow.Runtime/ActivityUtilities.cs
+++ b/src/UiPath.Workflow.Runtime/ActivityUtilities.cs
@@ -10,6 +10,7 @@ namespace System.Activities;
 using Expressions;
 using Internals;
 using Runtime;
+using System.Collections.Concurrent;
 using Validation;
 
 internal static class ActivityUtilities
@@ -47,6 +48,8 @@ internal static class ActivityUtilities
     private static readonly Type outArgumentOfObjectType = typeof(OutArgument<object>);
     private static readonly Type inOutArgumentOfObjectType = typeof(InOutArgument<object>);
     private static PropertyChangedEventArgs propertyChangedEventArgs;
+    
+    private static readonly ConcurrentDictionary<Type, ArgumentTypeInfo> argumentTypeCache = new();
 
     // Can't delay create this one because we use object.ReferenceEquals on it in WorkflowInstance
     private static readonly ReadOnlyDictionary<string, object> emptyParameters = new(new Dictionary<string, object>(0));
@@ -97,6 +100,18 @@ internal static class ActivityUtilities
 
     public static bool IsCompletedState(ActivityInstanceState state) => state != ActivityInstanceState.Executing;
 
+    private readonly struct ArgumentTypeInfo
+    {
+        public readonly ArgumentDirection Direction;
+        public readonly Type ArgumentType;
+
+        public ArgumentTypeInfo(ArgumentDirection direction, Type argumentType)
+        {
+            Direction = direction;
+            ArgumentType = argumentType;
+        }
+    }
+
     public static bool TryGetArgumentDirectionAndType(Type propertyType, out ArgumentDirection direction, out Type argumentType)
     {
         direction = ArgumentDirection.In; // default to In
@@ -104,24 +119,34 @@ internal static class ActivityUtilities
 
         if (propertyType.IsGenericType)
         {
+            if (argumentTypeCache.TryGetValue(propertyType, out ArgumentTypeInfo info))
+            {
+                direction = info.Direction;
+                argumentType = info.ArgumentType;
+                return true;
+            }
+
             argumentType = propertyType.GetGenericArguments()[0];
 
             Type genericType = propertyType.GetGenericTypeDefinition();
 
             if (genericType == inArgumentGenericType)
             {
+                argumentTypeCache.TryAdd(propertyType, new ArgumentTypeInfo(direction, argumentType));
                 return true;
             }
 
             if (genericType == outArgumentGenericType)
             {
                 direction = ArgumentDirection.Out;
+                argumentTypeCache.TryAdd(propertyType, new ArgumentTypeInfo(direction, argumentType));
                 return true;
             }
 
             if (genericType == inOutArgumentGenericType)
             {
                 direction = ArgumentDirection.InOut;
+                argumentTypeCache.TryAdd(propertyType, new ArgumentTypeInfo(direction, argumentType));
                 return true;
             }
         }

--- a/src/UiPath.Workflow.Runtime/AssemblyInfo.cs
+++ b/src/UiPath.Workflow.Runtime/AssemblyInfo.cs
@@ -28,4 +28,5 @@ using System.Windows.Markup;
 [assembly: InternalsVisibleTo("UiPath.Workflow")]
 [assembly: InternalsVisibleTo("TestCases.Workflows")]
 [assembly: InternalsVisibleTo("TestCases.Runtime")]
+[assembly: InternalsVisibleTo("CoreWf.Benchmarks")]
 [assembly: InternalsVisibleTo("Perf.AssemblyReference.Benchmarks")]


### PR DESCRIPTION
It's on a hot path and having quite an impact in a test project.

<img width="2555" height="773" alt="image" src="https://github.com/user-attachments/assets/542c1add-a577-472e-a3ee-5d4cb68eab4c" />

Benchmarks (warm):

|                Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|---------------------- |----------:|----------:|----------:|-------:|----------:|
|       ArgumentGeneric |  6.718 ns | 0.0759 ns | 0.0710 ns |      - |         - |
|    ArgumentNonGeneric |  1.799 ns | 0.0167 ns | 0.0139 ns |      - |         - |
|       NonArgumentType |  2.368 ns | 0.0308 ns | 0.0288 ns |      - |         - |
|    ArgumentGenericOld | 46.647 ns | 0.1908 ns | 0.1785 ns | 0.0018 |      32 B |
| ArgumentNonGenericOld |  3.054 ns | 0.0286 ns | 0.0267 ns |      - |         - |
|    NonArgumentTypeOld |  3.389 ns | 0.0504 ns | 0.0471 ns |      - |         - |

Benchmarks (cold):

|                Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|---------------------- |----------:|----------:|----------:|-------:|----------:|
|       ArgumentGeneric | 66.940 ns | 0.5590 ns | 0.4955 ns | 0.0018 |      32 B |
|    ArgumentNonGeneric |  2.196 ns | 0.0264 ns | 0.0247 ns |      - |         - |
|       NonArgumentType |  2.681 ns | 0.0470 ns | 0.0440 ns |      - |         - |
|    ArgumentGenericOld | 46.857 ns | 0.2948 ns | 0.2758 ns | 0.0018 |      32 B |
| ArgumentNonGenericOld |  2.868 ns | 0.0575 ns | 0.0480 ns |      - |         - |
|    NonArgumentTypeOld |  3.256 ns | 0.0414 ns | 0.0367 ns |      - |         - |

