### PR TITLE
CoreWF: Unexpected validation error received in the Expression Editor STUD-72767

### DIFF
--- a/src/Test/TestCases.Workflows/CSharpCompilerHelperTests.cs
+++ b/src/Test/TestCases.Workflows/CSharpCompilerHelperTests.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 
-namespace Test.TestCases.Activities
+namespace TestCases.Workflows
 {
     public class CSharpCompilerHelperTests
     {
@@ -124,6 +124,23 @@ namespace Test.TestCases.Activities
 
             // Assert
             result.ShouldContain("public delegate TResult Func");
+            result.ShouldContain("public static Expression<Func");
+            result.ShouldContain(code);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_WithLessThan16Parameters_ShouldNotGenerateCustomDelegate()
+        {
+            // Arrange
+            var types = Enumerable.Range(0, 5).Select(i => $"T{i}").ToArray();
+            var names = Enumerable.Range(0, 5).Select(i => $"arg{i}").ToArray();
+            var code = "arg0";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            result.ShouldNotContain("public delegate TResult Func");
             result.ShouldContain("public static Expression<Func");
             result.ShouldContain(code);
         }

--- a/src/Test/TestCases.Workflows/CSharpCompilerHelperTests.cs
+++ b/src/Test/TestCases.Workflows/CSharpCompilerHelperTests.cs
@@ -1,0 +1,224 @@
+﻿using System.Activities;
+using System.Linq;
+using Xunit;
+
+namespace Test.TestCases.Activities
+{
+    public class CSharpCompilerHelperTests
+    {
+        private readonly CSharpCompilerHelper _compilerHelper = new CSharpCompilerHelper();
+
+        [Fact]
+        public void CreateExpressionCode_WithPipeDelimitedTypes_ShouldSplitCorrectly()
+        {
+            // Arrange
+            var types = "string| int| bool";
+            var names = "arg1, arg2, arg3";
+            var code = "new object()";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            Assert.Contains("Func<string, int, bool>", result);
+            Assert.Contains("CreateExpression() => (arg1, arg2, arg3) => new object();", result);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_WithCommaDelimitedTypes_ShouldNotSplitCorrectly()
+        {
+            // Arrange - This tests the old behavior would be wrong
+            var types = "string, int, bool";
+            var names = "arg1, arg2, arg3";
+            var code = "new object()";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            // With pipe splitting, comma-delimited types will be treated as one type
+            Assert.Contains("Func<string, int, bool>", result);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_WithSixteenOrFewerParameters_ShouldUseBuiltInFunc()
+        {
+            // Arrange
+            var types = string.Join("| ", Enumerable.Range(0, 16).Select(_ => "string"));
+            var names = string.Join(", ", Enumerable.Range(0, 16).Select(i => $"arg{i}"));
+            var code = "\"result\"";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            Assert.Contains("Expression<Func<", result);
+            Assert.DoesNotContain("public delegate", result);
+            Assert.Contains("CreateExpression() =>", result);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_WithMoreThanSixteenParameters_ShouldUseCustomDelegate()
+        {
+            // Arrange
+            var types = string.Join("| ", Enumerable.Range(0, 17).Select(_ => "string"));
+            var names = string.Join(", ", Enumerable.Range(0, 17).Select(i => $"arg{i}"));
+            var code = "\"result\"";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            Assert.Contains("public delegate", result);
+            Assert.Contains("Func", result);
+            Assert.Contains("CreateExpression() =>", result);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_WithExactlySixteenParameters_ShouldUseBuiltInFunc()
+        {
+            // Arrange
+            var types = string.Join("| ", Enumerable.Range(0, 16).Select(_ => "string"));
+            var names = string.Join(", ", Enumerable.Range(0, 16).Select(i => $"arg{i}"));
+            var code = "\"result\"";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            Assert.Contains("Expression<Func<", result);
+            Assert.DoesNotContain("public delegate", result);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_WithSeventeenParameters_ShouldUseCustomDelegate()
+        {
+            // Arrange
+            var types = string.Join("| ", Enumerable.Range(0, 17).Select(_ => "string"));
+            var names = string.Join(", ", Enumerable.Range(0, 17).Select(i => $"arg{i}"));
+            var code = "\"result\"";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            Assert.Contains("public delegate", result);
+            Assert.Contains("Func", result);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_WithSingleParameter_ShouldUseBuiltInFunc()
+        {
+            // Arrange
+            var types = "string";
+            var names = "arg1";
+            var code = "\"result\"";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            Assert.Contains("Expression<Func<string>", result);
+            Assert.DoesNotContain("public delegate", result);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_WithNoParameters_ShouldUseBuiltInFunc()
+        {
+            // Arrange
+            var types = "";
+            var names = "";
+            var code = "\"result\"";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            Assert.Contains("Expression<Func<>", result);
+            Assert.DoesNotContain("public delegate", result);
+        }
+
+        [Theory]
+        [InlineData("string| int", "arg1, arg2", "new object()", "Func<string, int>")]
+        [InlineData("Dictionary<string, object>| List<int>", "dict, list", "dict.Count + list.Count", "Func<Dictionary<string, object>, List<int>>")]
+        [InlineData("System.Activities.InArgument<string>", "variable1", "new Dictionary<string, InArgument<string>>()", "Func<System.Activities.InArgument<string>>")]
+        public void CreateExpressionCode_WithVariousTypeFormats_ShouldHandleCorrectly(string types, string names, string code, string expectedFuncPattern)
+        {
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            Assert.Contains(expectedFuncPattern, result);
+            Assert.Contains($"({names}) => {code}", result);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_WithComplexGenericTypes_ShouldPreserveTypeStructure()
+        {
+            // Arrange
+            var types = "Dictionary<string, InArgument<string>>| List<Dictionary<int, string>>";
+            var names = "dict, list";
+            var code = "dict.Count";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            Assert.Contains("Dictionary<string, InArgument<string>>, List<Dictionary<int, string>>", result);
+            Assert.Contains("(dict, list) => dict.Count", result);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_EmptyInput_ShouldHandleGracefully()
+        {
+            // Act
+            var result = _compilerHelper.CreateExpressionCode("", "", "null");
+
+            // Assert
+            Assert.Contains("Expression<Func<>", result);
+            Assert.Contains("() => null", result);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_BoundaryTesting_FifteenVsSixteenVsSeventeenParams()
+        {
+            // Test 15 parameters (should use built-in Func)
+            var types15 = string.Join("| ", Enumerable.Range(0, 15).Select(_ => "string"));
+            var names15 = string.Join(", ", Enumerable.Range(0, 15).Select(i => $"arg{i}"));
+            var result15 = _compilerHelper.CreateExpressionCode(types15, names15, "\"test\"");
+
+            Assert.Contains("Expression<Func<", result15);
+            Assert.DoesNotContain("public delegate", result15);
+
+            // Test 16 parameters (should use built-in Func)
+            var types16 = string.Join("| ", Enumerable.Range(0, 16).Select(_ => "string"));
+            var names16 = string.Join(", ", Enumerable.Range(0, 16).Select(i => $"arg{i}"));
+            var result16 = _compilerHelper.CreateExpressionCode(types16, names16, "\"test\"");
+
+            Assert.Contains("Expression<Func<", result16);
+            Assert.DoesNotContain("public delegate", result16);
+
+            // Test 17 parameters (should use custom delegate)
+            var types17 = string.Join("| ", Enumerable.Range(0, 17).Select(_ => "string"));
+            var names17 = string.Join(", ", Enumerable.Range(0, 17).Select(i => $"arg{i}"));
+            var result17 = _compilerHelper.CreateExpressionCode(types17, names17, "\"test\"");
+
+            Assert.Contains("public delegate", result17);
+            Assert.Contains("Func", result17);
+        }
+
+        [Fact]
+        public void CreateExpressionCode_WithPipeInTypeName_ShouldNotBeSplitIncorrectly()
+        {
+            // This tests edge case where type names might contain pipe characters in generic constraints
+            // Though this is unlikely in practice, it's good to document the behavior
+            var types = "string";
+            var names = "arg1";
+            var code = "arg1";
+
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            Assert.Contains("Expression<Func<string>", result);
+        }
+    }
+}

--- a/src/Test/TestCases.Workflows/VBCompilerHelperTests.cs
+++ b/src/Test/TestCases.Workflows/VBCompilerHelperTests.cs
@@ -1,31 +1,30 @@
-﻿using System.Activities;
-using System.Linq;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis;
 using Shouldly;
 using System;
+using System.Activities;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
-namespace Test.TestCases.Activities
+namespace TestCases.Workflows
 {
-    public class CSharpCompilerHelperTests
+    public class VBCompilerHelperTests
     {
-        private readonly CSharpCompilerHelper _compilerHelper = new CSharpCompilerHelper();
+        private readonly VBCompilerHelper _compilerHelper = new VBCompilerHelper();
 
         [Fact]
         public void DefaultCompilationUnit_ShouldNotBeNull()
         {
             // Act & Assert
             _compilerHelper.DefaultCompilationUnit.ShouldNotBeNull();
-            _compilerHelper.DefaultCompilationUnit.ShouldBeOfType<CSharpCompilation>();
+            _compilerHelper.DefaultCompilationUnit.ShouldBeOfType<Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation>();
         }
 
         [Fact]
         public void IdentifierKind_ShouldReturnCorrectSyntaxKind()
         {
             // Act & Assert
-            _compilerHelper.IdentifierKind.ShouldBe((int)SyntaxKind.IdentifierName);
+            _compilerHelper.IdentifierKind.ShouldBe((int)Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.IdentifierName);
         }
 
         [Fact]
@@ -34,30 +33,30 @@ namespace Test.TestCases.Activities
             // Act & Assert
             _compilerHelper.ScriptParseOptions.ShouldNotBeNull();
             _compilerHelper.ScriptParseOptions.Kind.ShouldBe(SourceCodeKind.Script);
-            _compilerHelper.ScriptParseOptions.ShouldBeOfType<CSharpParseOptions>();
+            _compilerHelper.ScriptParseOptions.ShouldBeOfType<Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions>();
         }
 
         [Fact]
-        public void IdentifierNameComparer_ShouldBeOrdinal()
+        public void IdentifierNameComparer_ShouldBeOrdinalIgnoreCase()
         {
             // Act & Assert
-            _compilerHelper.IdentifierNameComparer.ShouldBe(StringComparer.Ordinal);
+            _compilerHelper.IdentifierNameComparer.ShouldBe(StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void IdentifierNameComparison_ShouldBeOrdinal()
+        public void IdentifierNameComparison_ShouldBeOrdinalIgnoreCase()
         {
             // Act & Assert
-            _compilerHelper.IdentifierNameComparison.ShouldBe(StringComparison.Ordinal);
+            _compilerHelper.IdentifierNameComparison.ShouldBe(StringComparison.OrdinalIgnoreCase);
         }
 
         [Theory]
-        [InlineData(typeof(string), "string")]
-        [InlineData(typeof(int), "int")]
-        [InlineData(typeof(bool), "bool")]
-        [InlineData(typeof(List<string>), "List<string>")]
-        [InlineData(typeof(Dictionary<string, int>), "Dictionary<string, int>")]
-        public void GetTypeName_ShouldReturnCorrectTypeNames(Type type, string expectedTypeName)
+        [InlineData(typeof(string), "String")]
+        [InlineData(typeof(int), "Integer")]
+        [InlineData(typeof(bool), "Boolean")]
+        [InlineData(typeof(List<string>), "List(Of String)")]
+        [InlineData(typeof(Dictionary<string, int>), "Dictionary(Of String, Integer)")]
+        public void GetTypeName_ShouldReturnCorrectVBTypeNames(Type type, string expectedTypeName)
         {
             // Act
             var result = _compilerHelper.GetTypeName(type);
@@ -67,10 +66,10 @@ namespace Test.TestCases.Activities
         }
 
         [Fact]
-        public void CreateExpressionCode_WithSimpleParameters_ShouldGenerateCorrectCode()
+        public void CreateExpressionCode_WithSimpleParameters_ShouldGenerateCorrectVBCode()
         {
             // Arrange
-            var types = new[] { "string", "int" };
+            var types = new[] { "String", "Integer" };
             var names = new[] { "name", "age" };
             var code = "name + age.ToString()";
 
@@ -78,14 +77,14 @@ namespace Test.TestCases.Activities
             var result = _compilerHelper.CreateExpressionCode(types, names, code);
 
             // Assert
-            result.ShouldBe("public static Expression<Func<string, int>> CreateExpression() => (name, age) => name + age.ToString();");
+            result.ShouldBe("Public Shared Function CreateExpression() As Expression(Of Func(Of String, Integer))\nReturn Function(name, age) (name + age.ToString())\nEnd Function");
         }
 
         [Fact]
-        public void CreateExpressionCode_WithSingleParameter_ShouldGenerateCorrectCode()
+        public void CreateExpressionCode_WithSingleParameter_ShouldGenerateCorrectVBCode()
         {
             // Arrange
-            var types = new[] { "string" };
+            var types = new[] { "String" };
             var names = new[] { "input" };
             var code = "input.ToUpper()";
 
@@ -93,11 +92,11 @@ namespace Test.TestCases.Activities
             var result = _compilerHelper.CreateExpressionCode(types, names, code);
 
             // Assert
-            result.ShouldBe("public static Expression<Func<string>> CreateExpression() => (input) => input.ToUpper();");
+            result.ShouldBe("Public Shared Function CreateExpression() As Expression(Of Func(Of String))\nReturn Function(input) (input.ToUpper())\nEnd Function");
         }
 
         [Fact]
-        public void CreateExpressionCode_WithNoParameters_ShouldGenerateCorrectCode()
+        public void CreateExpressionCode_WithNoParameters_ShouldGenerateCorrectVBCode()
         {
             // Arrange
             var types = Array.Empty<string>();
@@ -108,11 +107,11 @@ namespace Test.TestCases.Activities
             var result = _compilerHelper.CreateExpressionCode(types, names, code);
 
             // Assert
-            result.ShouldBe("public static Expression<Func<>> CreateExpression() => () => \"Hello World\";");
+            result.ShouldBe("Public Shared Function CreateExpression() As Expression(Of Func(Of ))\nReturn Function() (\"Hello World\")\nEnd Function");
         }
 
         [Fact]
-        public void CreateExpressionCode_WithMoreThan16Parameters_ShouldGenerateCustomDelegate()
+        public void CreateExpressionCode_WithMoreThan16Parameters_ShouldGenerateCustomVBDelegate()
         {
             // Arrange
             var types = Enumerable.Range(0, 17).Select(i => $"T{i}").ToArray();
@@ -123,8 +122,8 @@ namespace Test.TestCases.Activities
             var result = _compilerHelper.CreateExpressionCode(types, names, code);
 
             // Assert
-            result.ShouldContain("public delegate TResult Func");
-            result.ShouldContain("public static Expression<Func");
+            result.ShouldContain("Public Delegate Function Func");
+            result.ShouldContain("Public Shared Function CreateExpression() As Expression(Of Func");
             result.ShouldContain(code);
         }
 
@@ -133,7 +132,7 @@ namespace Test.TestCases.Activities
         [InlineData(5)]
         [InlineData(17)]
         [InlineData(22)]
-        public void DefineDelegateCommon_ShouldGenerateCorrectDelegate(int argumentsCount)
+        public void DefineDelegateCommon_ShouldGenerateCorrectVBDelegate(int argumentsCount)
         {
             // Act
             var (delegateDefinition, delegateName) = _compilerHelper.DefineDelegate(Enumerable.Range(0, argumentsCount + 1).Select(i => $"T{i}"));
@@ -141,40 +140,42 @@ namespace Test.TestCases.Activities
             // Assert
             delegateDefinition.ShouldNotBeNullOrEmpty();
             delegateName.ShouldNotBeNullOrEmpty();
-            delegateDefinition.ShouldStartWith("public delegate TResult");
+            delegateDefinition.ShouldStartWith("Public Delegate Function");
             delegateDefinition.ShouldContain(delegateName);
-            delegateDefinition.ShouldContain("out TResult");
+            delegateDefinition.ShouldContain("Out TResult");
 
             // Check parameter count
-            var parameterCount = delegateDefinition.Split("in T").Length - 1;
+            var parameterCount = delegateDefinition.Split(" In T").Length - 1;
             parameterCount.ShouldBe(argumentsCount);
         }
 
         [Fact]
-        public void DefineDelegate_WithStringArray_ShouldReturnCorrectDelegate()
+        public void DefineDelegate_WithStringArray_ShouldReturnCorrectVBDelegate()
         {
             // Arrange
-            var types = new[] { "string", "int", "bool" };
+            var types = new[] { "String", "Integer", "Boolean" };
 
             // Act
             var (delegateDefinition, delegateName) = _compilerHelper.DefineDelegate(types);
 
             // Assert
-            delegateDefinition.ShouldContain("in T0, in T1,  out TResult");
+            delegateDefinition.ShouldContain(" In T0, In T1, Out TResult");
+            delegateDefinition.ShouldContain("ByVal arg as T0, ByVal arg as T1");
             delegateName.ShouldStartWith("Func");
         }
 
         [Fact]
-        public void DefineDelegate_WithEnumerableTypes_ShouldReturnCorrectDelegate()
+        public void DefineDelegate_WithEnumerableTypes_ShouldReturnCorrectVBDelegate()
         {
             // Arrange
-            var types = new List<string> { "string", "int" };
+            var types = new List<string> { "String", "Integer" };
 
             // Act
             var (delegateDefinition, delegateName) = _compilerHelper.DefineDelegate(types);
 
             // Assert
-            delegateDefinition.ShouldContain("in T0,  out TResult");
+            delegateDefinition.ShouldContain(" In T0, Out TResult");
+            delegateDefinition.ShouldContain("ByVal arg as T0");
             delegateName.ShouldStartWith("Func");
         }
 
@@ -182,7 +183,7 @@ namespace Test.TestCases.Activities
         public void DefineDelegate_MultipleCalls_ShouldGenerateUniqueDelegateNames()
         {
             // Arrange
-            var types = new[] { "string", "int" };
+            var types = new[] { "String", "Integer" };
 
             // Act
             var (_, delegateName1) = _compilerHelper.DefineDelegate(types);
@@ -196,7 +197,7 @@ namespace Test.TestCases.Activities
         public void DefineDelegate_ObsoleteMethod_ShouldStillWork()
         {
             // Arrange
-            var types = "string, int, bool";
+            var types = "String, Integer, Boolean";
 
             // Act
             var (delegateDefinition, delegateName) = _compilerHelper.DefineDelegate(types);
@@ -204,17 +205,17 @@ namespace Test.TestCases.Activities
             // Assert
             delegateDefinition.ShouldNotBeNullOrEmpty();
             delegateName.ShouldNotBeNullOrEmpty();
-            delegateDefinition.ShouldContain("in T0, in T1,  out TResult");
+            delegateDefinition.ShouldContain(" In T0, In T1, Out TResult");
         }
 
         [Fact]
-        public void CSharpCompilerHelper_ShouldImplementAllCompilerHelperAbstractMembers()
+        public void VBCompilerHelper_ShouldImplementAllCompilerHelperAbstractMembers()
         {
             // Assert - Verify all abstract members are implemented
             _compilerHelper.DefaultCompilationUnit.ShouldNotBeNull();
             _compilerHelper.ScriptParseOptions.ShouldNotBeNull();
             _compilerHelper.IdentifierNameComparer.ShouldNotBeNull();
-            _compilerHelper.IdentifierNameComparison.ShouldBe(StringComparison.Ordinal);
+            _compilerHelper.IdentifierNameComparison.ShouldBe(StringComparison.OrdinalIgnoreCase);
             _compilerHelper.IdentifierKind.ShouldBeGreaterThan(0);
 
             // Test that GetTypeName works
@@ -222,7 +223,7 @@ namespace Test.TestCases.Activities
             typeName.ShouldNotBeNullOrEmpty();
 
             // Test that CreateExpressionCode works
-            var expressionCode = _compilerHelper.CreateExpressionCode(new[] { "string" }, new[] { "input" }, "input");
+            var expressionCode = _compilerHelper.CreateExpressionCode(new[] { "String" }, new[] { "input" }, "input");
             expressionCode.ShouldNotBeNullOrEmpty();
         }
     }

--- a/src/Test/TestCases.Workflows/VBCompilerHelperTests.cs
+++ b/src/Test/TestCases.Workflows/VBCompilerHelperTests.cs
@@ -127,6 +127,23 @@ namespace TestCases.Workflows
             result.ShouldContain(code);
         }
 
+        [Fact]
+        public void CreateExpressionCode_WithLessThan16Parameters_ShouldNotGenerateCustomVBDelegate()
+        {
+            // Arrange
+            var types = Enumerable.Range(0, 5).Select(i => $"T{i}").ToArray();
+            var names = Enumerable.Range(0, 5).Select(i => $"arg{i}").ToArray();
+            var code = "arg0";
+
+            // Act
+            var result = _compilerHelper.CreateExpressionCode(types, names, code);
+
+            // Assert
+            result.ShouldNotContain("Public Delegate Function Func");
+            result.ShouldContain("Public Shared Function CreateExpression() As Expression(Of Func");
+            result.ShouldContain(code);
+        }
+
         [Theory]
         [InlineData(1)]
         [InlineData(5)]

--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -61,7 +61,7 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
                 .Where(var => var.Type != null)
                 .ToArray();
         var names = string.Join(CompilerHelper.Comma, resolvedIdentifiers.Select(var => var.Name));
-        var types = string.Join(CompilerHelper.Comma,
+        var types = string.Join(CompilerHelper.Pipe,
             resolvedIdentifiers
                 .Select(var => var.Type)
                 .Concat(new[] { expressionToCompile.LambdaReturnType })

--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -60,12 +60,8 @@ public abstract class ScriptingJitCompiler : JustInTimeCompiler
                 .Select(name => (Name: name, Type: expressionToCompile.VariableTypeGetter(name, CompilerHelper.IdentifierNameComparison)))
                 .Where(var => var.Type != null)
                 .ToArray();
-        var names = string.Join(CompilerHelper.Comma, resolvedIdentifiers.Select(var => var.Name));
-        var types = string.Join(CompilerHelper.Pipe,
-            resolvedIdentifiers
-                .Select(var => var.Type)
-                .Concat(new[] { expressionToCompile.LambdaReturnType })
-                .Select(GetTypeName));
+        var names = resolvedIdentifiers.Select(var => var.Name).ToArray();
+        var types = resolvedIdentifiers.Select(var => var.Type).Concat(new[] { expressionToCompile.LambdaReturnType }).Select(GetTypeName).ToArray();
         var finalCompilation = compilation.ReplaceSyntaxTree(syntaxTree, syntaxTree.WithChangedText(SourceText.From(
             CompilerHelper.CreateExpressionCode(types, names, expressionToCompile.Code))));
 

--- a/src/UiPath.Workflow/Activities/Utils/CSharpCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CSharpCompilerHelper.cs
@@ -28,16 +28,15 @@ namespace System.Activities
         public override string GetTypeName(Type type) =>
             (string)s_typeNameFormatter.FormatTypeName(type, s_typeOptions);
 
-        public override string CreateExpressionCode(string types, string names, string code)
+        public override string CreateExpressionCode(string[] types, string[] names, string code)
         {
-            var arrayType = types.Split(Pipe);
-            var normTypeStr = string.Join(CompilerHelper.Comma, arrayType);
+            var typesStr = string.Join(CompilerHelper.Comma, types);
+            var namesStr = string.Join(CompilerHelper.Comma, names);
+            if (types.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
+                return $"public static Expression<Func<{typesStr}>> CreateExpression() => ({namesStr}) => {code};";
 
-            if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
-                return $"public static Expression<Func<{normTypeStr}>> CreateExpression() => ({names}) => {code};";
-
-            var (myDelegate, name) = DefineDelegate(arrayType);
-            return $"{myDelegate} \n public static Expression<{name}<{normTypeStr}>> CreateExpression() => ({names}) => {code};";
+            var (myDelegate, name) = DefineDelegate(types);
+            return $"{myDelegate} \n public static Expression<{name}<{typesStr}>> CreateExpression() => ({namesStr}) => {code};";
         }
 
         protected override (string, string) DefineDelegateCommon(int argumentsCount)

--- a/src/UiPath.Workflow/Activities/Utils/CSharpCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CSharpCompilerHelper.cs
@@ -30,12 +30,14 @@ namespace System.Activities
 
         public override string CreateExpressionCode(string types, string names, string code)
         {
-            var arrayType = types.Split(Comma);
-            if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
-                return $"public static Expression<Func<{types}>> CreateExpression() => ({names}) => {code};";
+            var arrayType = types.Split(Pipe);
+            var normTypeStr = string.Join(CompilerHelper.Comma, arrayType);
 
-            var (myDelegate, name) = DefineDelegate(types);
-            return $"{myDelegate} \n public static Expression<{name}<{types}>> CreateExpression() => ({names}) => {code};";
+            if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
+                return $"public static Expression<Func<{normTypeStr}>> CreateExpression() => ({names}) => {code};";
+
+            var (myDelegate, name) = DefineDelegate(arrayType);
+            return $"{myDelegate} \n public static Expression<{name}<{normTypeStr}>> CreateExpression() => ({names}) => {code};";
         }
 
         protected override (string, string) DefineDelegateCommon(int argumentsCount)

--- a/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
@@ -13,6 +13,7 @@ namespace System.Activities
         };
 
         public const string Comma = ", ";
+        public const string Pipe = "| ";
 
         public abstract string CreateExpressionCode(string types, string names, string code);
 

--- a/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
@@ -13,9 +13,8 @@ namespace System.Activities
         };
 
         public const string Comma = ", ";
-        public const string Pipe = "| ";
 
-        public abstract string CreateExpressionCode(string types, string names, string code);
+        public abstract string CreateExpressionCode(string[] types, string[] names, string code);
 
         public abstract StringComparer IdentifierNameComparer { get; }
 

--- a/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
@@ -26,12 +26,14 @@ namespace System.Activities
 
         public override string CreateExpressionCode(string types, string names, string code)
         {
-            var arrayType = types.Split(Comma);
-            if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
-                return $"Public Shared Function CreateExpression() As Expression(Of Func(Of {types}))\nReturn Function({names}) ({code})\nEnd Function";
+            var arrayType = types.Split(Pipe);
+            var normTypeStr = string.Join(CompilerHelper.Comma, arrayType);
 
-            var (myDelegate, name) = DefineDelegate(types);
-            return $"{myDelegate} \n Public Shared Function CreateExpression() As Expression(Of {name}(Of {types}))\nReturn Function({names}) ({code})\nEnd Function";
+            if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
+                return $"Public Shared Function CreateExpression() As Expression(Of Func(Of {normTypeStr}))\nReturn Function({names}) ({code})\nEnd Function";
+
+            var (myDelegate, name) = DefineDelegate(arrayType);
+            return $"{myDelegate} \n Public Shared Function CreateExpression() As Expression(Of {name}(Of {normTypeStr}))\nReturn Function({names}) ({code})\nEnd Function";
         }
 
         protected override (string, string) DefineDelegateCommon(int argumentsCount)

--- a/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
@@ -9,7 +9,7 @@ namespace System.Activities
 {
     public sealed class VBCompilerHelper : CompilerHelper
     {
-        private static int crt = 0;
+        private int crt = 0;
 
         public override Compilation DefaultCompilationUnit { get; } = InitDefaultCompilationUnit();
 
@@ -24,16 +24,15 @@ namespace System.Activities
 
         public override string GetTypeName(Type type) => VisualBasicObjectFormatter.FormatTypeName(type);
 
-        public override string CreateExpressionCode(string types, string names, string code)
+        public override string CreateExpressionCode(string[] types, string[] names, string code)
         {
-            var arrayType = types.Split(Pipe);
-            var normTypeStr = string.Join(CompilerHelper.Comma, arrayType);
+            var typesStr = string.Join(CompilerHelper.Comma, types);
+            var namesStr = string.Join(CompilerHelper.Comma, names);
+            if (types.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
+                return $"Public Shared Function CreateExpression() As Expression(Of Func(Of {typesStr}))\nReturn Function({namesStr}) ({code})\nEnd Function";
 
-            if (arrayType.Length <= 16) // .net defines Func<TResult>...Funct<T1,...T16,TResult)
-                return $"Public Shared Function CreateExpression() As Expression(Of Func(Of {normTypeStr}))\nReturn Function({names}) ({code})\nEnd Function";
-
-            var (myDelegate, name) = DefineDelegate(arrayType);
-            return $"{myDelegate} \n Public Shared Function CreateExpression() As Expression(Of {name}(Of {normTypeStr}))\nReturn Function({names}) ({code})\nEnd Function";
+            var (myDelegate, name) = DefineDelegate(types);
+            return $"{myDelegate} \n Public Shared Function CreateExpression() As Expression(Of {name}(Of {typesStr}))\nReturn Function({namesStr}) ({code})\nEnd Function";
         }
 
         protected override (string, string) DefineDelegateCommon(int argumentsCount)
@@ -45,7 +44,7 @@ namespace System.Activities
             for (var i = 0; i < argumentsCount; i++)
             {
                 part1.Append($" In T{i},");
-                part2.Append($" ByVal arg as T{i},");
+                part2.Append($" ByVal arg{i} as T{i},");
             }
             part2.Remove(part2.Length - 1, 1);
 

--- a/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/VBCompilerHelper.cs
@@ -9,7 +9,7 @@ namespace System.Activities
 {
     public sealed class VBCompilerHelper : CompilerHelper
     {
-        private int crt = 0;
+        private static int crt = 0;
 
         public override Compilation DefaultCompilationUnit { get; } = InitDefaultCompilationUnit();
 
@@ -44,7 +44,7 @@ namespace System.Activities
             for (var i = 0; i < argumentsCount; i++)
             {
                 part1.Append($" In T{i},");
-                part2.Append($" ByVal arg{i} as T{i},");
+                part2.Append($" ByVal arg as T{i},");
             }
             part2.Remove(part2.Length - 1, 1);
 

--- a/src/UiPath.Workflow/Microsoft/CSharp/CSharpExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/CSharpExpressionCompiler.cs
@@ -49,9 +49,8 @@ internal sealed class CSharpExpressionCompiler : ExpressionCompiler
                 .Where(var => var.Type != null)
                 .ToArray();
 
-        var names = string.Join(CompilerHelper.Comma, resolvedIdentifiers.Select(var => var.Name));
-        // We use a Pipe (|) as a separator because certain types can contain commas (e.g., tuples).
-        var types = string.Join(CompilerHelper.Pipe, resolvedIdentifiers.Select(var => var.Type).Concat(new[] { returnType }).Select(_compilerHelper.GetTypeName));
+        var names = resolvedIdentifiers.Select(var => var.Name).ToArray();
+        var types = resolvedIdentifiers.Select(var => var.Type).Concat(new[] { returnType }).Select(_compilerHelper.GetTypeName).ToArray();
         var lambdaFuncCode = _compilerHelper.CreateExpressionCode(types, names, expression);
         return CSharpSyntaxTree.ParseText(lambdaFuncCode, _compilerHelper.ScriptParseOptions);
     }

--- a/src/UiPath.Workflow/Microsoft/CSharp/CSharpExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/CSharpExpressionCompiler.cs
@@ -50,7 +50,8 @@ internal sealed class CSharpExpressionCompiler : ExpressionCompiler
                 .ToArray();
 
         var names = string.Join(CompilerHelper.Comma, resolvedIdentifiers.Select(var => var.Name));
-        var types = string.Join(CompilerHelper.Comma, resolvedIdentifiers.Select(var => var.Type).Concat(new[] { returnType }).Select(_compilerHelper.GetTypeName));
+        // We use a Pipe (|) as a separator because certain types can contain commas (e.g., tuples).
+        var types = string.Join(CompilerHelper.Pipe, resolvedIdentifiers.Select(var => var.Type).Concat(new[] { returnType }).Select(_compilerHelper.GetTypeName));
         var lambdaFuncCode = _compilerHelper.CreateExpressionCode(types, names, expression);
         return CSharpSyntaxTree.ParseText(lambdaFuncCode, _compilerHelper.ScriptParseOptions);
     }

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
@@ -49,9 +49,8 @@ internal sealed class VisualBasicExpressionCompiler : ExpressionCompiler
                 .Where(var => var.Type != null)
                 .ToArray();
 
-        var names = string.Join(CompilerHelper.Comma, resolvedIdentifiers.Select(var => var.Name));
-        // We use a Pipe (|) as a separator because certain types can contain commas (e.g., tuples).
-        var types = string.Join(CompilerHelper.Pipe, resolvedIdentifiers.Select(var => var.Type).Concat(new[] { returnType }).Select(_compilerHelper.GetTypeName));
+        var names = resolvedIdentifiers.Select(var => var.Name).ToArray();
+        var types = resolvedIdentifiers.Select(var => var.Type).Concat(new[] { returnType }).Select(_compilerHelper.GetTypeName).ToArray();
         var lambdaFuncCode = _compilerHelper.CreateExpressionCode(types, names, expression);
         return VisualBasicSyntaxTree.ParseText(lambdaFuncCode, _compilerHelper.ScriptParseOptions);
     }

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/VisualBasicExpressionCompiler.cs
@@ -50,7 +50,8 @@ internal sealed class VisualBasicExpressionCompiler : ExpressionCompiler
                 .ToArray();
 
         var names = string.Join(CompilerHelper.Comma, resolvedIdentifiers.Select(var => var.Name));
-        var types = string.Join(CompilerHelper.Comma, resolvedIdentifiers.Select(var => var.Type).Concat(new[] { returnType }).Select(_compilerHelper.GetTypeName));
+        // We use a Pipe (|) as a separator because certain types can contain commas (e.g., tuples).
+        var types = string.Join(CompilerHelper.Pipe, resolvedIdentifiers.Select(var => var.Type).Concat(new[] { returnType }).Select(_compilerHelper.GetTypeName));
         var lambdaFuncCode = _compilerHelper.CreateExpressionCode(types, names, expression);
         return VisualBasicSyntaxTree.ParseText(lambdaFuncCode, _compilerHelper.ScriptParseOptions);
     }


### PR DESCRIPTION
Description:
Changed the type string parsing from using commas to using pipes (|) as separators when joining type information, because certain types (like tuples) can contain commas within their names, which would break the parsing logic.


Jira:
https://uipath.atlassian.net/browse/STUD-72767