### PR TITLE
CoreWF: Add necessary .NET version on CI pipeline STUD-77010

### DIFF
--- a/.pipelines/build.yaml
+++ b/.pipelines/build.yaml
@@ -4,6 +4,12 @@ jobs:
   pool:
     vmImage: windows-2022
   steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET SDK 6.0.317'
+    inputs:
+      packageType: 'sdk'
+      version: '6.0.317'
+
   - task: PowerShell@2
     displayName: Get Version from Directory.Build.props
     inputs:

--- a/.pipelines/build.yaml
+++ b/.pipelines/build.yaml
@@ -10,6 +10,12 @@ jobs:
       packageType: 'sdk'
       version: '6.0.317'
 
+  - task: UseDotNet@2
+    displayName: 'Use .NET SDK 8.0.408'
+    inputs:
+      packageType: 'sdk'
+      version: '8.0.408'
+
   - task: PowerShell@2
     displayName: Get Version from Directory.Build.props
     inputs:

--- a/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
@@ -16,6 +16,7 @@ namespace System.Activities
 
         public abstract string CreateExpressionCode(string types, string names, string code);
 
+
         public abstract StringComparer IdentifierNameComparer { get; }
 
         public abstract StringComparison IdentifierNameComparison { get; }

--- a/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/Utils/CompilerHelper.cs
@@ -16,7 +16,6 @@ namespace System.Activities
 
         public abstract string CreateExpressionCode(string types, string names, string code);
 
-
         public abstract StringComparer IdentifierNameComparer { get; }
 
         public abstract StringComparison IdentifierNameComparison { get; }


### PR DESCRIPTION
## Description
The CI pipelines triggered on prs are failing due to the agents not having the right .NET version. This pr adds 2 steps that install .NET 6 and .NET 8.

## Jira
https://uipath.atlassian.net/browse/STUD-77010