### PR TITLE
Set SourceDetail on FlowDecision, FlowSwitch and FlowNode validation errors STUD-79314

### DIFF
--- a/src/UiPath.Workflow.Runtime/Statements/FlowDecision.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/FlowDecision.cs
@@ -56,7 +56,10 @@ public sealed class FlowDecision : FlowNode
     {
         if (Condition == null)
         {
-            metadata.AddValidationError(SR.FlowDecisionRequiresCondition(owner.DisplayName));
+            metadata.AddValidationError(new Validation.ValidationError(SR.FlowDecisionRequiresCondition(owner.DisplayName))
+            {
+                SourceDetail = new object[] { this }
+            });
         }
     }
 

--- a/src/UiPath.Workflow.Runtime/Statements/FlowNode.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/FlowNode.cs
@@ -29,10 +29,7 @@ public abstract class FlowNode
             // We've already visited this node during this pass
             if (!ReferenceEquals(_owner, owner))
             {
-                metadata.AddValidationError(new Validation.ValidationError(SR.FlowNodeCannotBeShared(_owner.DisplayName, owner.DisplayName))
-            {
-                SourceDetail = new object[] { this }
-            });
+                metadata.AddValidationError(SR.FlowNodeCannotBeShared(_owner.DisplayName, owner.DisplayName));
             }
 
             // Whether we found an issue or not we don't want to change

--- a/src/UiPath.Workflow.Runtime/Statements/FlowNode.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/FlowNode.cs
@@ -29,7 +29,10 @@ public abstract class FlowNode
             // We've already visited this node during this pass
             if (!ReferenceEquals(_owner, owner))
             {
-                metadata.AddValidationError(SR.FlowNodeCannotBeShared(_owner.DisplayName, owner.DisplayName));
+                metadata.AddValidationError(new Validation.ValidationError(SR.FlowNodeCannotBeShared(_owner.DisplayName, owner.DisplayName))
+            {
+                SourceDetail = new object[] { this }
+            });
             }
 
             // Whether we found an issue or not we don't want to change

--- a/src/UiPath.Workflow.Runtime/Statements/FlowSwitch.cs
+++ b/src/UiPath.Workflow.Runtime/Statements/FlowSwitch.cs
@@ -36,7 +36,10 @@ public sealed class FlowSwitch<T> : FlowNode, IFlowSwitch
     {
         if (Expression == null)
         {
-            metadata.AddValidationError(SR.FlowSwitchRequiresExpression(owner.DisplayName));
+            metadata.AddValidationError(new Validation.ValidationError(SR.FlowSwitchRequiresExpression(owner.DisplayName))
+            {
+                SourceDetail = new object[] { this }
+            });
         }
     }
 


### PR DESCRIPTION
## Description
FlowDecision and FlowSwitch validation errors now set `SourceDetail` to the FlowNode instance

## Related PRs
https://github.com/UiPath/Studio/pull/27321

## Jira
https://uipath.atlassian.net/browse/STUD-79314