### PR TITLE
chore: change to centralized managed GitHub pool

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   lock:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@f1a42f0f44eb83361d617a014663e1a76cf282d2  # v2.1.2
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: 15


### PR DESCRIPTION
## Summary

Moves this repository's workflows to the centralized managed GitHub pool.

- Runner images are prefixed with `uipath-` in all workflow files
- e.g. `ubuntu-latest` → `uipath-ubuntu-latest`

## Changes

All workflow `.yml` files (including non-standard locations like `workflows-src/`) with static `runs-on` values are updated.
Dynamic expressions (`${{ ... }}`) and already-prefixed images are skipped.

## Action Version Pinning

All `uses:` references are pinned to the SHA of the latest release published ≥ **48h** ago.
This prevents supply-chain attacks via recently-published compromised versions.